### PR TITLE
Change to using libyaml-dev, to speed up pyyaml

### DIFF
--- a/dockerfiles/lucid/Dockerfile
+++ b/dockerfiles/lucid/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update
 
 RUN apt-get -y install dpkg-dev python-tox python-setuptools
-RUN apt-get -y install python-dev debhelper libyaml-0-2 libcurl4-openssl-dev
+RUN apt-get -y install python-dev debhelper libyaml-dev libcurl4-openssl-dev
 RUN apt-get -y install python2.7
 RUN apt-get -y install python2.7-dev
 

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update
 
 RUN apt-get -y install dpkg-dev python-tox python-setuptools
-RUN apt-get -y install python-dev debhelper libyaml-0-2 libcurl4-openssl-dev
+RUN apt-get -y install python-dev debhelper libyaml-dev libcurl4-openssl-dev
 
 # Older versions of dh-virtualenv are buggy and don't.. work
 RUN curl http://ppa.launchpad.net/dh-virtualenv/daily/ubuntu/pool/main/d/dh-virtualenv/dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb --output dh-virtualenv_0.10-0~80~ubuntu14.04.1_all.deb && \


### PR DESCRIPTION
If we have to build our own wheel, we need libyaml-dev headers in order
to get C accelerated yaml parsing.