### PR TITLE
Use shlib deps

### DIFF
--- a/dockerfiles/itest/itest/Dockerfile.lucid
+++ b/dockerfiles/itest/itest/Dockerfile.lucid
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get -y install  \
     rbenv \
     rbenv-ruby-1.9.3-p448 \
     libcurl3 \
-    libyaml-0-2 \
     python2.7 \
     hacheck
 

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get -y install  \
     socat \
     ruby1.9.1 ruby1.9.1-dev rubygems1.9.1 zlib1g-dev libopenssl-ruby1.9.1 \
     libcurl3 \
-    libyaml-0-2 \
     python2.7 \
     git \
     python-pip

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
-
 echo "Installing nerve-tools package"
 dpkg -i /work/dist/nerve-tools_*.deb
+
+# Set -e here because the previous install should fail lacking dependencies
+# and then we can fix it here
+set -e
+apt-get -y install -f
 
 echo "Testing that pyyaml uses optimized cyaml parsers if present"
 /usr/share/python/nerve-tools/bin/python -c 'import yaml; assert yaml.__with_libyaml__'

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.9.3) lucid; urgency=low
+
+  * Use shlibs for dependency mgmt
+
+ -- Joseph Lynch <jlynch@yelp.com>  Thu, 7 Jan 2016 12:03:30 -0800
+
 nerve-tools (0.9.2) lucid; urgency=low
 
   * Fix pyyaml build to use c libyaml when possible

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python2.7
+Depends: python2.7, ${shlibs:Depends}
 Package: nerve-tools
 Architecture: any
 Description: Nerve-related tools for use on Yelp machines.

--- a/src/nerve_tools/clean_nerve.py
+++ b/src/nerve_tools/clean_nerve.py
@@ -12,6 +12,7 @@ import argparse
 import kazoo.client
 import kazoo.exceptions
 import yaml
+from yaml import CLoader
 
 
 # CEP 355 Zookeepers
@@ -44,7 +45,7 @@ def get_zk_topology(cluster_type, cluster_location):
         ZK_TOPOLOGY_DIR, cluster_type, cluster_location + '.yaml'
     )
     with open(zk_topology_path) as fp:
-        zk_topology = yaml.load(fp)
+        zk_topology = yaml.load(fp, Loader=CLoader)
     return ['%s:%d' % (entry[0], entry[1]) for entry in zk_topology]
 
 

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import sys
 import yaml
+from yaml import CLoader
 
 from environment_tools.type_utils import compare_types
 from environment_tools.type_utils import convert_location_type
@@ -56,7 +57,7 @@ def get_named_zookeeper_topology(cluster_type, cluster_location):
         ZK_TOPOLOGY_DIR, cluster_type, cluster_location + '.yaml'
     )
     with open(zk_topology_path) as fp:
-        zk_topology = yaml.load(fp)
+        zk_topology = yaml.load(fp, Loader=CLoader)
     return ['%s:%d' % (entry[0], entry[1]) for entry in zk_topology]
 
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.9.2',
+    version='0.9.3',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
This forces nerve-tools to install libyaml via shlibs. Also let's use CLoader for the zookeeper topo files as well (instead of just for service_configuration_lib) 