### PR TITLE
Add healthcheck_mode parameter, bump version to 0.10.0

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.10.0) lucid; urgency=low
+
+  * Add healthcheck_mode parameter
+
+ -- Federico Giraud <fgiraud@yelp.com>  Mon, 11 Jan 2016 07:11:10 -0800
+
 nerve-tools (0.9.3) lucid; urgency=low
 
   * Use shlibs for dependency mgmt

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -145,10 +145,11 @@ def generate_configuration(services, heartbeat_path):
         healthcheck_timeout_s = service_info.get('healthcheck_timeout_s', 1.0)
         healthcheck_port = service_info.get('healthcheck_port', port)
 
-        # hacheck will simply ignore this for a TCP mode service
+        # hacheck will simply ignore the healthcheck_uri for TCP mode checks
         healthcheck_uri = service_info.get('healthcheck_uri', '/status')
+        healthcheck_mode = service_info.get('healthcheck_mode', mode)
         hacheck_uri = '/%s/%s/%s/%s' % (
-            mode, service_name, healthcheck_port, healthcheck_uri.lstrip('/'))
+            healthcheck_mode, service_name, healthcheck_port, healthcheck_uri.lstrip('/'))
         advertise = service_info.get('advertise', ['region'])
         extra_advertise = service_info.get('extra_advertise', [])
         extra_healthcheck_headers = service_info.get('extra_healthcheck_headers', {})

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.9.3',
+    version='0.10.0',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
Currently configure_nerve uses the mode parameter for both the service mode and the healthcheck mode. This means that TCP services cannot have HTTP checks, because the hacheck uri will always be '/tcp/...'.

This change introduces a new configuration parameter called healthcheck_mode that specifies the mode of the check. If not specified, it defaults to the service mode, so it is fully backward compatible.