### PR TITLE
Upgrade paasta-tools, bump version to 0.10.1

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.10.1) lucid; urgency=low
+
+  * Upgrade paasta-tools
+
+ -- Federico Giraud <fgiraud@yelp.com>  Tue, 08 Mar 2016 11:33:00 -0800
+
 nerve-tools (0.10.0) lucid; urgency=low
 
   * Add healthcheck_mode parameter

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 environment_tools==1.1.0
-paasta-tools==0.16.10
+paasta-tools==0.16.27
 kazoo==2.0.0
 PyYAML==3.11
 requests==2.6.2

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.10.0',
+    version='0.10.1',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
paasta-tools includes a change that nerve-tools needs in order to make the healthcheck_mode work.