### PR TITLE
Public package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dockerfiles/trusty/location_types.json
 src/.cache/
 dockerfiles/lucid/location_types.json
 dockerfiles/lucid/location_mapping.json
+bintray.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ services:
   - docker
 install: pip install tox
 script: make itest_trusty
+deploy:
+  - provider: bintray
+    file: "bintray.json"
+    user: yelptravis
+    key:
+      secure: "hfC9w1BH2fnCxiFeQDB9Gx+MpbB8lbkVKgvUa0u4IytBFD11zFOlotj3HbgBgV79mk8tYqB858Z3+n3acLeuY9sg9NuTESrDmH73TY0tOyG6WARoLZHgp8Ezt8SHkl8oPmmbN6TrVYCRh/SLPPOmXhjiAzgaTrZAcwDspYa2BDVd2rnaqS6vS4MgyAz/Wv7DxLJWflpeU8F38c2K7Mp5ydGpaVX9tp6pYAMZIwZZ013ncqQPJjePqIEBfBC6hR8/FgchnLaehkpWaj8gJHzOatR3dPq7FjaOQNvRo/pfTVbYZ1R+AfrKpfd8e3U3uORcK0gmiLTxlkj0Oj86UAC08374HG8hTX9hv8mRwmSHUq8NiFNSeEmYtR2C78DpYyPpzCZgaJJbwl/l/NXZSlEZ6Y7iBydFPxOvg/d2r6IM1X2e3TEMpsMJLGrtio2ydXzG5q36dds5poH50G7W/M0e6zf1LjRJKRhGPKDV0Bzw9/YsBwTR/qNaI63/H+52r1DX9SbUfMaZiJ8p5zq4H87vfNKQAB9SzdoCJYEl+EOcbiXRtm6uM1mKYFGIak1Z86NwoaahPlKau3x249eIk7iYjx1DbDdh78TLbvMXSsp0XjVYWKs/3S7rbRa0gf0PVhm48GiUbbOw0rwL02cR5UOheVwA20qdE2qHMFN7rERIJ5M="
+    on:
+      tags: true
+      repo: Yelp/nerve-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branch:
+  only:
+    - master
 language: python
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ deploy:
     key:
       secure: "hfC9w1BH2fnCxiFeQDB9Gx+MpbB8lbkVKgvUa0u4IytBFD11zFOlotj3HbgBgV79mk8tYqB858Z3+n3acLeuY9sg9NuTESrDmH73TY0tOyG6WARoLZHgp8Ezt8SHkl8oPmmbN6TrVYCRh/SLPPOmXhjiAzgaTrZAcwDspYa2BDVd2rnaqS6vS4MgyAz/Wv7DxLJWflpeU8F38c2K7Mp5ydGpaVX9tp6pYAMZIwZZ013ncqQPJjePqIEBfBC6hR8/FgchnLaehkpWaj8gJHzOatR3dPq7FjaOQNvRo/pfTVbYZ1R+AfrKpfd8e3U3uORcK0gmiLTxlkj0Oj86UAC08374HG8hTX9hv8mRwmSHUq8NiFNSeEmYtR2C78DpYyPpzCZgaJJbwl/l/NXZSlEZ6Y7iBydFPxOvg/d2r6IM1X2e3TEMpsMJLGrtio2ydXzG5q36dds5poH50G7W/M0e6zf1LjRJKRhGPKDV0Bzw9/YsBwTR/qNaI63/H+52r1DX9SbUfMaZiJ8p5zq4H87vfNKQAB9SzdoCJYEl+EOcbiXRtm6uM1mKYFGIak1Z86NwoaahPlKau3x249eIk7iYjx1DbDdh78TLbvMXSsp0XjVYWKs/3S7rbRa0gf0PVhm48GiUbbOw0rwL02cR5UOheVwA20qdE2qHMFN7rERIJ5M="
     on:
-      tags: true
+      branch: master
       repo: Yelp/nerve-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+sudo: required
+services:
+  - docker
+install: pip install tox
+script: make itest_trusty

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 all: itest_trusty
 
-itest_trusty: package_trusty
+itest_trusty: package_trusty bintray.json
 	rm -rf dockerfiles/itest/itest_trusty
 	cp -a dockerfiles/itest/itest dockerfiles/itest/itest_trusty
 	cp dockerfiles/itest/itest/Dockerfile.trusty dockerfiles/itest/itest_trusty/Dockerfile
 	tox -e itest_trusty
+
+DATE := $(shell date +'%Y-%m-%d')
+NERVETOOLSVERSION := $(shell sed 's/.*(\(.*\)).*/\1/;q' src/debian/changelog)
+bintray.json: bintray.json.in src/debian/changelog
+	sed -e 's/@DATE@/$(DATE)/g' -e 's/@NERVETOOLSVERSION@/$(NERVETOOLSVERSION)/g' $< > $@
 
 package_trusty:
 	[ -d dist ] || mkdir dist

--- a/bintray.json.in
+++ b/bintray.json.in
@@ -1,0 +1,33 @@
+{
+    "package": {
+        "name": "nerve-tools",
+        "repo": "paasta",
+        "subject": "yelp",
+        "desc": "Tools for configuring nerve",
+        "website_url": "paasta.readthedocs.org",
+        "issue_tracker_url": "https://github.com/Yelp/nerve-tools/issues",
+        "vcs_url": "https://github.com/Yelp/nerve-tools.git",
+        "github_use_tag_release_notes": true,
+        "github_release_notes_file": "RELEASE.md",
+        "licenses": ["Apache-2.0"],
+        "labels": [],
+        "public_download_numbers": false,
+        "public_stats": false,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "@NERVETOOLSVERSION@",
+        "desc": "Version @NERVETOOLSVERSION@",
+        "released": "@DATE@",
+        "vcs_tag": "v@NERVETOOLSVERSION@",
+        "attributes": [],
+        "gpgSign": false
+    },
+
+    "files":
+        [
+        {"includePattern": "dist/(nerve-tools.*\.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "trusty", "deb_component": "main", "deb_architecture": "amd64"} }
+        ],
+    "publish": true
+}


### PR DESCRIPTION
This branch builds itest_trusty with travis, and for tagged versions, pushes the built .deb to [Bintray](https://bintray.com/yelp/paasta/nerve-tools/view).

Similar to Yelp/paasta#337

Fixes #6 