### PR TITLE
Fix setup version typo

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.10.3) lucid; urgency=low
+
+  * Fix typo in setup.py
+
+ -- Federico Giraud <fgiraud@yelp.com>  Tue, 22 Mar 2016 08:17:27 -0700
+
 nerve-tools (0.10.2) lucid; urgency=low
 
   * Upgrade paasta-tools in setup.py

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.10.2',
+    version='0.10.3',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,7 +18,7 @@ setup(
         'environment_tools>=1.1.0,<1.2.0',
         'kazoo>=2.0.0',
         'PyYAML>=3.11',
-        'paasta-tools==0.16.17',
+        'paasta-tools==0.16.27',
         'requests>=2.6.2',
         'service-configuration-lib==0.10.0',
     ],


### PR DESCRIPTION
The paasta-tools version in setup.py doesn't correspond with the one in requirements.txt.