### PR TITLE
Less hard-coding, more options.

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -5,7 +5,7 @@
 install_command = pip install --no-use-wheel --upgrade {opts} {packages}
 basepython=python2.7
 deps =
-     -r/work/src/requirements.txt
+    -r{toxinidir}/requirements.txt
     flake8
     pytest
     mock==1.0.1


### PR DESCRIPTION
This removes all the hard-coded values in configure_nerve and makes them command line options, with defaults that are the same as they were previously hard-coded to.

This means it should be a drop-in replacement if you don't pass any options, but would allow for environments where hacheck doesn't run on 6666, ZK discovery files are in a different directory, or ZK clusters live at a different location type than 'superregion'.