### PR TITLE
When reloading with sighups, always try to stop the nerve-backup process

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.11.1) lucid; urgency=low
+
+  * Always stop nerve-backup after sighups
+
+ -- Joseph Lynch <jlynch@yelp.com>  Fri, 05 Aug 2016 00:09:19 -0700
+
 nerve-tools (0.11.0) lucid; urgency=low
 
   * Support fancy sighup reloads

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -252,6 +252,9 @@ def main():
             except (OSError, ValueError, IOError):
                 # invalid pid file, time to restart
                 should_restart = True
+            else:
+                # Always try to stop the backup process
+                subprocess.call(opts.nerve_backup_command + ['stop'])
         else:
             should_restart |= should_reload
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.11.0',
+    version='0.11.1',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
@jnb This fixes the bug I saw yesterday in staging where the backup process just ran forever and ever.