### PR TITLE
Move nerve config rather than copy

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -60,7 +60,9 @@ def setup():
     hacheck_process = subprocess.Popen('/usr/bin/hacheck -p 6666'.split())
 
     try:
-        subprocess.check_call(['configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100'])
+        subprocess.check_call(
+            ['configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100', '--nerve-registration-delay-s', '0']
+        )
 
         # Normally configure_nerve would start up nerve using 'service nerve start'.
         # However, this silently fails because we don't have an init process in our
@@ -161,7 +163,9 @@ def test_nerve_restarted_if_stale_heartbeat(setup):
     os.utime(HEARTBEAT_PATH, (0, 0))
 
     # Run configure_nerve and check if nerve was restarted
-    subprocess.check_call(['configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100'])
+    subprocess.check_call(
+        ['configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100', '--nerve-registration-delay-s', '0']
+    )
     proc = subprocess.Popen(['ps aux | grep "[b]in/nerve" | wc -l'], stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
     assert int(out) == 1
@@ -202,7 +206,7 @@ def test_sighup_handling(setup):
         subprocess.check_call([
             'configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100',
             '--nerve-executable-path', '/usr/bin/nerve',
-            '--reload-with-sighup'
+            '--reload-with-sighup', '--nerve-registration-delay-s', '0'
         ])
 
         expected_services = [service['name'] for service in SERVICES[:-1]]
@@ -216,7 +220,7 @@ def test_sighup_handling(setup):
         subprocess.check_call([
             'configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100',
             '--nerve-executable-path', '/usr/bin/nerve',
-            '--reload-with-sighup'
+            '--reload-with-sighup', '--nerve-registration-delay-s', '0'
         ])
         expected_services = [service['name'] for service in SERVICES]
         _check_zk_for_services(zk, expected_services)
@@ -232,7 +236,7 @@ def test_sighup_handling(setup):
         subprocess.check_call([
             'configure_nerve', '-f', HEARTBEAT_PATH, '-s', '100',
             '--nerve-executable-path', '/usr/bin/nerve',
-            '--reload-with-sighup'
+            '--reload-with-sighup', '--nerve-registration-delay-s', '0'
         ])
         expected_services = [service['name'] for service in service_copy]
         _check_zk_for_services(zk, expected_services, service_copy)

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.11.2) lucid; urgency=low
+
+  * Use atomic file renames
+
+ -- Joseph Lynch <jlynch@yelp.com>  Tue, 16 Aug 2016 15:17:48 -0700
+
 nerve-tools (0.11.1) lucid; urgency=low
 
   * Always stop nerve-backup after sighups

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.11.1',
+    version='0.11.2',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
So... copying files is not atomic, which means we can kill nerve by
telling it to read a file which won't exist or will partially exist.
Let's stop doing that.