### PR TITLE
write to /nerve/all for all advertise regions

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -108,6 +108,13 @@ def test_nerve_services(setup):
         # Puppet-configured services
         'scribe.main.westcoast-dev.region:sjc-dev.1464.new',
         'mysql_read.main.westcoast-dev.region:sjc-dev.1464.new',
+
+        # V2 configs
+        'service_three.main.westcoast-dev.region:sjc-dev.1024.v2.new',
+        'service_three.main.westcoast-prod.region:uswest1-prod.1024.v2.new',
+        'service_one.main.westcoast-dev.region:sjc-dev.1025.v2.new',
+        'scribe.main.westcoast-dev.region:sjc-dev.1464.v2.new',
+        'mysql_read.main.westcoast-dev.region:sjc-dev.1464.v2.new',
     ]
 
     with open('/etc/nerve/nerve.conf.json') as fd:
@@ -151,6 +158,44 @@ def test_nerve_service_config(setup):
         nerve_config = json.load(fd)
     actual_service_entry = \
         nerve_config['services'].get('service_three.main.westcoast-dev.region:sjc-dev.1024.new')
+
+    assert expected_service_entry == actual_service_entry
+
+
+def test_v2_nerve_service_config(setup):
+    # Check a single v2 nerve service entry
+    expected_service_entry = {
+        "check_interval": 2.0,
+        "checks": [
+            {
+                "fall": 2,
+                "host": "127.0.0.1",
+                "port": 6666,
+                "rise": 1,
+                "timeout": 1.0,
+                "open_timeout": 1.0,
+                "type": "http",
+                "uri": "/http/service_three.main/1024/status",
+                "headers": {
+                    "Host": "www.test.com",
+                },
+            },
+        ],
+        "host": MY_IP_ADDRESS,
+        "port": 1024,
+        "weight": CPUS,
+        "zk_hosts": [ZOOKEEPER_CONNECT_STRING],
+        "zk_path": "/nerve/all/service_three.main",
+        'labels': {
+            'weight': CPUS,
+            'region': 'sjc-dev',
+        },
+    }
+
+    with open('/etc/nerve/nerve.conf.json') as fd:
+        nerve_config = json.load(fd)
+    actual_service_entry = \
+        nerve_config['services'].get('service_three.main.westcoast-dev.region:sjc-dev.1024.v2.new')
 
     assert expected_service_entry == actual_service_entry
 

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -110,11 +110,11 @@ def test_nerve_services(setup):
         'mysql_read.main.westcoast-dev.region:sjc-dev.1464.new',
 
         # V2 configs
-        'service_three.main.westcoast-dev.region:sjc-dev.1024.v2.new',
-        'service_three.main.westcoast-prod.region:uswest1-prod.1024.v2.new',
-        'service_one.main.westcoast-dev.region:sjc-dev.1025.v2.new',
-        'scribe.main.westcoast-dev.region:sjc-dev.1464.v2.new',
-        'mysql_read.main.westcoast-dev.region:sjc-dev.1464.v2.new',
+        'service_three.main.westcoast-dev:1024.v2.new',
+        'service_three.main.westcoast-prod:1024.v2.new',
+        'service_one.main.westcoast-dev:1025.v2.new',
+        'scribe.main.westcoast-dev:1464.v2.new',
+        'mysql_read.main.westcoast-dev:1464.v2.new',
     ]
 
     with open('/etc/nerve/nerve.conf.json') as fd:
@@ -150,7 +150,10 @@ def test_nerve_service_config(setup):
         "zk_path": "/nerve/region:sjc-dev/service_three.main",
         'labels': {
             'weight': CPUS,
+            'habitat': 'dev',
             'region': 'sjc-dev',
+            'superregion': 'westcoast-dev',
+            'ecosystem': 'dev-ecosystem',
         },
     }
 
@@ -185,17 +188,20 @@ def test_v2_nerve_service_config(setup):
         "port": 1024,
         "weight": CPUS,
         "zk_hosts": [ZOOKEEPER_CONNECT_STRING],
-        "zk_path": "/nerve/all/service_three.main",
+        "zk_path": "/smartstack/global/service_three.main",
         'labels': {
             'weight': CPUS,
+            'habitat': 'dev',
             'region': 'sjc-dev',
+            'superregion': 'westcoast-dev',
+            'ecosystem': 'dev-ecosystem',
         },
     }
 
     with open('/etc/nerve/nerve.conf.json') as fd:
         nerve_config = json.load(fd)
     actual_service_entry = \
-        nerve_config['services'].get('service_three.main.westcoast-dev.region:sjc-dev.1024.v2.new')
+            nerve_config['services'].get('service_three.main.westcoast-dev:1024.v2.new')
 
     assert expected_service_entry == actual_service_entry
 
@@ -240,7 +246,10 @@ def _check_zk_for_services(zk, expected_services, all_services=SERVICES):
                 'name': 'itesthost.itestdomain',
                 'labels': {
                     'weight': CPUS,
-                    'region': service['path'].split('/')[2].split(':')[1],
+                    'habitat': 'dev',
+                    'region': 'sjc-dev',
+                    'superregion': 'westcoast-dev',
+                    'ecosystem': 'dev-ecosystem',
                 },
             }
 

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -46,7 +46,10 @@ def test_generate_subconfiguration():
             'weight': 1,
             'labels': {
                 'weight': 1,
+                'habitat': 'my_habitat',
                 'region': 'my_region',
+                'superregion': 'my_superregion',
+                'ecosystem': 'my_ecosystem',
             },
         },
         'test_service.my_superregion.superregion:my_superregion.1234.new': {
@@ -69,7 +72,10 @@ def test_generate_subconfiguration():
             'weight': 1,
             'labels': {
                 'weight': 1,
+                'habitat': 'my_habitat',
+                'region': 'my_region',
                 'superregion': 'my_superregion',
+                'ecosystem': 'my_ecosystem',
             },
         },
         'test_service.another_superregion.region:another_region.1234.new': {
@@ -92,36 +98,15 @@ def test_generate_subconfiguration():
             'weight': 1,
             'labels': {
                 'weight': 1,
-                'region': 'another_region',
-            },
-        },
-        'test_service.my_superregion.region:my_region.1234.v2.new': {
-            'zk_hosts': ['1.2.3.4', '2.3.4.5'],
-            'zk_path': '/nerve/all/test_service',
-            'checks': [{
-                'rise': 1,
-                'uri': '/http/test_service/1234/status',
-                'host': '127.0.0.1',
-                'timeout': 2.0,
-                'open_timeout': 2.0,
-                'fall': 2,
-                'type': 'http',
-                'port': 6666,
-                'headers': {},
-            }],
-            'host': 'ip_address',
-            'check_interval': 3.0,
-            'port': 1234,
-            'weight': 1,
-            'labels': {
-                'weight': 1,
+                'habitat': 'my_habitat',
                 'region': 'my_region',
                 'superregion': 'my_superregion',
+                'ecosystem': 'my_ecosystem',
             },
         },
-        'test_service.another_superregion.region:another_region.1234.v2.new': {
-            'zk_hosts': ['3.4.5.6', '4.5.6.7'],
-            'zk_path': '/nerve/all/test_service',
+        'test_service.my_superregion:1234.v2.new': {
+            'zk_hosts': ['1.2.3.4', '2.3.4.5'],
+            'zk_path': '/smartstack/global/test_service',
             'checks': [{
                 'rise': 1,
                 'uri': '/http/test_service/1234/status',
@@ -139,13 +124,43 @@ def test_generate_subconfiguration():
             'weight': 1,
             'labels': {
                 'weight': 1,
-                'region': 'another_region',
+                'habitat': 'my_habitat',
+                'region': 'my_region',
+                'superregion': 'my_superregion',
+                'ecosystem': 'my_ecosystem',
+            },
+        },
+        'test_service.another_superregion:1234.v2.new': {
+            'zk_hosts': ['3.4.5.6', '4.5.6.7'],
+            'zk_path': '/smartstack/global/test_service',
+            'checks': [{
+                'rise': 1,
+                'uri': '/http/test_service/1234/status',
+                'host': '127.0.0.1',
+                'timeout': 2.0,
+                'open_timeout': 2.0,
+                'fall': 2,
+                'type': 'http',
+                'port': 6666,
+                'headers': {},
+            }],
+            'host': 'ip_address',
+            'check_interval': 3.0,
+            'port': 1234,
+            'weight': 1,
+            'labels': {
+                'weight': 1,
+                'habitat': 'my_habitat',
+                'region': 'my_region',
+                'superregion': 'my_superregion',
+                'ecosystem': 'my_ecosystem',
             },
         },
     }
 
     def get_current_location(typ):
         return {
+            'ecosystem': 'my_ecosystem',
             'superregion': 'my_superregion',
             'habitat': 'my_habitat',
             'region': 'my_region',
@@ -193,12 +208,6 @@ def test_generate_subconfiguration():
             zk_topology_dir='/fake/path',
             zk_location_type='superregion',
             zk_cluster_type='infrastructure',
-            location_depth_mapping={
-                'ecosystem': 0,
-                'superregion': 1,
-                'region': 2,
-                'habitat': 3,
-            },
         )
 
     assert expected_config == actual_config
@@ -256,12 +265,6 @@ def test_generate_configuration():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
-            location_depth_mapping={
-                'ecosystem': 0,
-                'superregion': 1,
-                'region': 2,
-                'habitat': 3,
-            },
         )
 
     assert expected_config == actual_config
@@ -321,12 +324,6 @@ def test_generate_configuration_healthcheck_port():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
-            location_depth_mapping={
-                'ecosystem': 0,
-                'superregion': 1,
-                'region': 2,
-                'habitat': 3,
-            },
         )
 
     assert expected_config == actual_config
@@ -387,12 +384,6 @@ def test_generate_configuration_healthcheck_mode():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
-            location_depth_mapping={
-                'ecosystem': 0,
-                'superregion': 1,
-                'region': 2,
-                'habitat': 3,
-            },
         )
 
     assert expected_config == actual_config

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -49,6 +49,29 @@ def test_generate_subconfiguration():
                 'region': 'my_region',
             },
         },
+        'test_service.my_superregion.superregion:my_superregion.1234.new': {
+            'zk_hosts': ['1.2.3.4', '2.3.4.5'],
+            'zk_path': '/nerve/superregion:my_superregion/test_service',
+            'checks': [{
+                'rise': 1,
+                'uri': '/http/test_service/1234/status',
+                'host': '127.0.0.1',
+                'timeout': 2.0,
+                'open_timeout': 2.0,
+                'fall': 2,
+                'type': 'http',
+                'port': 6666,
+                'headers': {},
+            }],
+            'host': 'ip_address',
+            'check_interval': 3.0,
+            'port': 1234,
+            'weight': 1,
+            'labels': {
+                'weight': 1,
+                'superregion': 'my_superregion',
+            },
+        },
         'test_service.another_superregion.region:another_region.1234.new': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/nerve/region:another_region/test_service',
@@ -71,7 +94,54 @@ def test_generate_subconfiguration():
                 'weight': 1,
                 'region': 'another_region',
             },
-        }
+        },
+        'test_service.my_superregion.region:my_region.1234.v2.new': {
+            'zk_hosts': ['1.2.3.4', '2.3.4.5'],
+            'zk_path': '/nerve/all/test_service',
+            'checks': [{
+                'rise': 1,
+                'uri': '/http/test_service/1234/status',
+                'host': '127.0.0.1',
+                'timeout': 2.0,
+                'open_timeout': 2.0,
+                'fall': 2,
+                'type': 'http',
+                'port': 6666,
+                'headers': {},
+            }],
+            'host': 'ip_address',
+            'check_interval': 3.0,
+            'port': 1234,
+            'weight': 1,
+            'labels': {
+                'weight': 1,
+                'region': 'my_region',
+                'superregion': 'my_superregion',
+            },
+        },
+        'test_service.another_superregion.region:another_region.1234.v2.new': {
+            'zk_hosts': ['3.4.5.6', '4.5.6.7'],
+            'zk_path': '/nerve/all/test_service',
+            'checks': [{
+                'rise': 1,
+                'uri': '/http/test_service/1234/status',
+                'host': '127.0.0.1',
+                'timeout': 2.0,
+                'open_timeout': 2.0,
+                'fall': 2,
+                'type': 'http',
+                'port': 6666,
+                'headers': {},
+            }],
+            'host': 'ip_address',
+            'check_interval': 3.0,
+            'port': 1234,
+            'weight': 1,
+            'labels': {
+                'weight': 1,
+                'region': 'another_region',
+            },
+        },
     }
 
     def get_current_location(typ):
@@ -81,13 +151,16 @@ def test_generate_subconfiguration():
             'region': 'my_region',
         }[typ]
 
-    def convert_location_type(src_typ, src_loc, dst_typ):
+    def convert_location_type(src_loc, src_typ, dst_typ):
+        if src_typ == dst_typ:
+            return [src_loc]
         return {
-            ('my_superregion', 'superregion', 'region'): ['my_region'],
+            ('my_superregion', 'superregion', 'superregion'): ['my_superregion'],
+            ('another_superregion', 'superregion', 'region'): ['another_region'],
             ('my_region', 'region', 'superregion'): ['my_superregion'],
             ('another_region', 'region', 'region'): ['another_region'],
             ('another_region', 'region', 'superregion'): ['another_superregion'],
-        }[(src_typ, src_loc, dst_typ)]
+        }[(src_loc, src_typ, dst_typ)]
 
     def get_named_zookeeper_topology(cluster_type, cluster_location, zk_topology_dir):
         return {
@@ -105,7 +178,7 @@ def test_generate_subconfiguration():
 
         actual_config = configure_nerve.generate_subconfiguration(
             service_name='test_service',
-            advertise=['region'],
+            advertise=['region', 'superregion'],
             extra_advertise=[
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
@@ -120,6 +193,12 @@ def test_generate_subconfiguration():
             zk_topology_dir='/fake/path',
             zk_location_type='superregion',
             zk_cluster_type='infrastructure',
+            location_depth_mapping={
+                'ecosystem': 0,
+                'superregion': 1,
+                'region': 2,
+                'habitat': 3,
+            },
         )
 
     assert expected_config == actual_config
@@ -135,13 +214,15 @@ def test_generate_configuration():
     }
 
     with contextlib.nested(
+        mock.patch('nerve_tools.configure_nerve.available_location_types',
+                   return_value=['ecosystem', 'superregion', 'region', 'habitat']),
         mock.patch('nerve_tools.configure_nerve.get_ip_address',
                    return_value='ip_address'),
         mock.patch('nerve_tools.configure_nerve.get_hostname',
                    return_value='my_host'),
         mock.patch('nerve_tools.configure_nerve.generate_subconfiguration',
                    return_value={'foo': 17})) as (
-            _, _, mock_generate_subconfiguration):
+                        _, _, _, mock_generate_subconfiguration):
 
         actual_config = configure_nerve.generate_configuration(
             services=[(
@@ -175,6 +256,12 @@ def test_generate_configuration():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'ecosystem': 0,
+                'superregion': 1,
+                'region': 2,
+                'habitat': 3,
+            },
         )
 
     assert expected_config == actual_config
@@ -190,13 +277,15 @@ def test_generate_configuration_healthcheck_port():
     }
 
     with contextlib.nested(
+        mock.patch('nerve_tools.configure_nerve.available_location_types',
+                   return_value=['ecosystem', 'superregion', 'region', 'habitat']),
         mock.patch('nerve_tools.configure_nerve.get_ip_address',
                    return_value='ip_address'),
         mock.patch('nerve_tools.configure_nerve.get_hostname',
                    return_value='my_host'),
         mock.patch('nerve_tools.configure_nerve.generate_subconfiguration',
                    return_value={'foo': 17})) as (
-            _, _, mock_generate_subconfiguration):
+            _, _, _, mock_generate_subconfiguration):
 
         actual_config = configure_nerve.generate_configuration(
             services=[(
@@ -232,6 +321,12 @@ def test_generate_configuration_healthcheck_port():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'ecosystem': 0,
+                'superregion': 1,
+                'region': 2,
+                'habitat': 3,
+            },
         )
 
     assert expected_config == actual_config
@@ -247,13 +342,15 @@ def test_generate_configuration_healthcheck_mode():
     }
 
     with contextlib.nested(
+        mock.patch('nerve_tools.configure_nerve.available_location_types',
+                   return_value=['ecosystem', 'superregion', 'region', 'habitat']),
         mock.patch('nerve_tools.configure_nerve.get_ip_address',
                    return_value='ip_address'),
         mock.patch('nerve_tools.configure_nerve.get_hostname',
                    return_value='my_host'),
         mock.patch('nerve_tools.configure_nerve.generate_subconfiguration',
                    return_value={'foo': 17})) as (
-            _, _, mock_generate_subconfiguration):
+            _, _, _, mock_generate_subconfiguration):
 
         actual_config = configure_nerve.generate_configuration(
             services=[(
@@ -266,7 +363,7 @@ def test_generate_configuration_healthcheck_mode():
                     'healthcheck_port': 7890,
                     'advertise': ['region'],
                     'extra_advertise': [('habitat:my_habitat', 'region:another_region')],
-                }
+                },
             )],
             heartbeat_path='test',
             hacheck_port=6666,
@@ -290,6 +387,12 @@ def test_generate_configuration_healthcheck_mode():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'ecosystem': 0,
+                'superregion': 1,
+                'region': 2,
+                'habitat': 3,
+            },
         )
 
     assert expected_config == actual_config


### PR DESCRIPTION
This will write nodes annotated with labels into `/nerve/all` in addition to the current locations. This will enable us to create smartstack backends using filters from the nodes in `/nerve/all`

@jolynch @jnb @solarkennedy 