### PR TITLE
duplicate and annotate extra_advertise nodes with metadata

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -195,7 +195,6 @@ def test_v2_nerve_service_config(setup):
             'region': 'sjc-dev',
             'superregion': 'westcoast-dev',
             'ecosystem': 'dev-ecosystem',
-            'remote': 'false',
         },
     }
 

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -110,11 +110,11 @@ def test_nerve_services(setup):
         'mysql_read.main.westcoast-dev.region:sjc-dev.1464.new',
 
         # V2 configs
-        'service_three.main.westcoast-dev:1024.v2.new',
-        'service_three.main.westcoast-prod:1024.v2.new',
-        'service_one.main.westcoast-dev:1025.v2.new',
-        'scribe.main.westcoast-dev:1464.v2.new',
-        'mysql_read.main.westcoast-dev:1464.v2.new',
+        'service_three.main.westcoast-dev:sjc-dev.1024.v2.new',
+        'service_three.main.westcoast-prod:uswest1-prod.1024.v2.new',
+        'service_one.main.westcoast-dev:sjc-dev.1025.v2.new',
+        'scribe.main.westcoast-dev:sjc-dev.1464.v2.new',
+        'mysql_read.main.westcoast-dev:sjc-dev.1464.v2.new',
     ]
 
     with open('/etc/nerve/nerve.conf.json') as fd:
@@ -195,13 +195,14 @@ def test_v2_nerve_service_config(setup):
             'region': 'sjc-dev',
             'superregion': 'westcoast-dev',
             'ecosystem': 'dev-ecosystem',
+            'remote': 'false',
         },
     }
 
     with open('/etc/nerve/nerve.conf.json') as fd:
         nerve_config = json.load(fd)
     actual_service_entry = \
-            nerve_config['services'].get('service_three.main.westcoast-dev:1024.v2.new')
+            nerve_config['services'].get('service_three.main.westcoast-dev:sjc-dev.1024.v2.new')
 
     assert expected_service_entry == actual_service_entry
 

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -153,6 +153,8 @@ def generate_subconfiguration(
             )
 
             if v2_key not in config and typ == most_specific_advertise:
+                # we create duplicate (host, port) pairs when discover !=
+                # most_specific_advertise and rely on Synapse to dedup
                 labels = default_labels.copy()
                 if get_current_location(typ) != loc:
                     # this is an extra_advertise, create remote labels

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -128,7 +128,6 @@ def test_generate_subconfiguration():
                 'region': 'my_region',
                 'superregion': 'my_superregion',
                 'ecosystem': 'my_ecosystem',
-                'remote': 'false',
             },
         },
         'test_service.another_superregion:another_region.1234.v2.new': {
@@ -155,8 +154,7 @@ def test_generate_subconfiguration():
                 'region': 'my_region',
                 'superregion': 'my_superregion',
                 'ecosystem': 'my_ecosystem',
-                'remote': 'true',
-                'remote_dst_loc': 'another_region',
+                'remote_region': 'another_region',
             },
         },
     }
@@ -197,7 +195,6 @@ def test_generate_subconfiguration():
         actual_config = configure_nerve.generate_subconfiguration(
             service_name='test_service',
             advertise=['region', 'superregion'],
-            discover='region',
             extra_advertise=[
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
@@ -212,6 +209,12 @@ def test_generate_subconfiguration():
             zk_topology_dir='/fake/path',
             zk_location_type='superregion',
             zk_cluster_type='infrastructure',
+            location_depth_mapping={
+                'habitat': 3,
+                'region': 2,
+                'superregion': 1,
+                'ecosystem': 0,
+            },
         )
 
     assert expected_config == actual_config
@@ -258,7 +261,6 @@ def test_generate_configuration():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
-            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',
@@ -270,6 +272,12 @@ def test_generate_configuration():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'habitat': 3,
+                'region': 2,
+                'superregion': 1,
+                'ecosystem': 0,
+            },
         )
 
     assert expected_config == actual_config
@@ -318,7 +326,6 @@ def test_generate_configuration_healthcheck_port():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
-            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',
@@ -330,6 +337,12 @@ def test_generate_configuration_healthcheck_port():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'habitat': 3,
+                'region': 2,
+                'superregion': 1,
+                'ecosystem': 0,
+            },
         )
 
     assert expected_config == actual_config
@@ -379,7 +392,6 @@ def test_generate_configuration_healthcheck_mode():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
-            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',
@@ -391,6 +403,12 @@ def test_generate_configuration_healthcheck_mode():
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
+            location_depth_mapping={
+                'habitat': 3,
+                'region': 2,
+                'superregion': 1,
+                'ecosystem': 0,
+            },
         )
 
     assert expected_config == actual_config

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -104,7 +104,7 @@ def test_generate_subconfiguration():
                 'ecosystem': 'my_ecosystem',
             },
         },
-        'test_service.my_superregion:1234.v2.new': {
+        'test_service.my_superregion:my_region.1234.v2.new': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/smartstack/global/test_service',
             'checks': [{
@@ -128,9 +128,10 @@ def test_generate_subconfiguration():
                 'region': 'my_region',
                 'superregion': 'my_superregion',
                 'ecosystem': 'my_ecosystem',
+                'remote': 'false',
             },
         },
-        'test_service.another_superregion:1234.v2.new': {
+        'test_service.another_superregion:another_region.1234.v2.new': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/smartstack/global/test_service',
             'checks': [{
@@ -154,6 +155,8 @@ def test_generate_subconfiguration():
                 'region': 'my_region',
                 'superregion': 'my_superregion',
                 'ecosystem': 'my_ecosystem',
+                'remote': 'true',
+                'remote_dst_loc': 'another_region',
             },
         },
     }
@@ -194,6 +197,7 @@ def test_generate_subconfiguration():
         actual_config = configure_nerve.generate_subconfiguration(
             service_name='test_service',
             advertise=['region', 'superregion'],
+            discover='region',
             extra_advertise=[
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
@@ -254,6 +258,7 @@ def test_generate_configuration():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
+            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',
@@ -313,6 +318,7 @@ def test_generate_configuration_healthcheck_port():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
+            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',
@@ -373,6 +379,7 @@ def test_generate_configuration_healthcheck_mode():
         mock_generate_subconfiguration.assert_called_once_with(
             service_name='test_service',
             advertise=['region'],
+            discover='region',
             extra_advertise=[('habitat:my_habitat', 'region:another_region')],
             port=1234,
             ip_address='ip_address',


### PR DESCRIPTION
@jolynch @solarkennedy In order to fix the problems in https://github.com/Yelp/synapse-tools/pull/11 without using huge number of labels, we're putting the burden on nerve to add metadata for `extra_advertise` nodes.