### PR TITLE
removed the weight field

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -145,7 +145,6 @@ def test_nerve_service_config(setup):
         ],
         "host": MY_IP_ADDRESS,
         "port": 1024,
-        "weight": CPUS,
         "zk_hosts": [ZOOKEEPER_CONNECT_STRING],
         "zk_path": "/nerve/region:sjc-dev/service_three.main",
         'labels': {
@@ -186,7 +185,6 @@ def test_v2_nerve_service_config(setup):
         ],
         "host": MY_IP_ADDRESS,
         "port": 1024,
-        "weight": CPUS,
         "zk_hosts": [ZOOKEEPER_CONNECT_STRING],
         "zk_path": "/smartstack/global/service_three.main",
         'labels': {
@@ -239,7 +237,6 @@ def _check_zk_for_services(zk, expected_services, all_services=SERVICES):
 
             payload = zk.get('%s/%s' % (service['path'], children[0]))[0]
             data = json.loads(payload)
-            del data['weight']
             assert data == {
                 'host': MY_IP_ADDRESS,
                 'port': service['port'],

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -127,7 +127,6 @@ def generate_subconfiguration(
             config[key] = {
                 'port': port,
                 'host': ip_address,
-                'weight': weight,
                 'zk_hosts': zookeeper_topology,
                 'zk_path': '/nerve/%s:%s/%s' % (typ, loc, service_name),
                 'check_interval': healthcheck_timeout_s + 1.0,
@@ -164,7 +163,6 @@ def generate_subconfiguration(
                 config[v2_key] = {
                     'port': port,
                     'host': ip_address,
-                    'weight': weight,
                     'zk_hosts': zookeeper_topology,
                     'zk_path': '/smartstack/global/%s' % service_name,
                     'check_interval': healthcheck_timeout_s + 1.0,

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -43,7 +43,6 @@ def test_generate_subconfiguration():
             'host': 'ip_address',
             'check_interval': 3.0,
             'port': 1234,
-            'weight': 1,
             'labels': {
                 'weight': 1,
                 'habitat': 'my_habitat',
@@ -69,7 +68,6 @@ def test_generate_subconfiguration():
             'host': 'ip_address',
             'check_interval': 3.0,
             'port': 1234,
-            'weight': 1,
             'labels': {
                 'weight': 1,
                 'habitat': 'my_habitat',
@@ -95,7 +93,6 @@ def test_generate_subconfiguration():
             'host': 'ip_address',
             'check_interval': 3.0,
             'port': 1234,
-            'weight': 1,
             'labels': {
                 'weight': 1,
                 'habitat': 'my_habitat',
@@ -121,7 +118,6 @@ def test_generate_subconfiguration():
             'host': 'ip_address',
             'check_interval': 3.0,
             'port': 1234,
-            'weight': 1,
             'labels': {
                 'weight': 1,
                 'habitat': 'my_habitat',
@@ -147,7 +143,6 @@ def test_generate_subconfiguration():
             'host': 'ip_address',
             'check_interval': 3.0,
             'port': 1234,
-            'weight': 1,
             'labels': {
                 'weight': 1,
                 'habitat': 'my_habitat',


### PR DESCRIPTION
Removed the weight field from service subconfigurations.

This is required before Synapse can be upgraded to the latest version.