### PR TITLE
Modernize updown_service for paasta services

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,3 +6,4 @@ PyYAML==3.11
 requests==2.6.2
 service-configuration-lib==0.10.1
 functools32==3.2.3-2
+setuptools==33.1.1

--- a/src/setup.py
+++ b/src/setup.py
@@ -23,6 +23,7 @@ setup(
         'requests>=2.6.2',
         'service-configuration-lib==0.10.1',
         'functools32==3.2.3-2',
+        'setuptools<34',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This makes it so that developers can do:

```bash
updown_service apollo.main:12345 down
```

And it'll do the right thing. This will help prevent the proliferation of hadown/haup in runbooks that will be hard to change if we decide to go with something other than hacheck.