### PR TITLE
Fix command when port is supplied

### DIFF
--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -19,9 +19,16 @@ RUN apt-get -y install \
     libcurl4-openssl-dev \
     dh-virtualenv \
     build-essential \
+    wget \
+    gdebi-core \
     protobuf-compiler
 
 ADD location_types.json /nail/etc/services/
 ADD location_mapping.json /nail/etc/services/
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 WORKDIR /work

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -13,7 +13,14 @@ RUN apt-get update && apt-get -y install \
     libcurl4-openssl-dev \
     dh-virtualenv \
     build-essential \
-    protobuf-compiler
+    protobuf-compiler \
+    gdebi-core \
+    wget
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 ADD location_types.json /nail/etc/services/
 ADD location_mapping.json /nail/etc/services/

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -5,10 +5,21 @@ export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 
 export DH_OPTIONS
 
-LSBDISTRELEASE := $(shell lsb_release -sr)
-
 %:
 	dh $@ --with python-virtualenv
 
+# do not call `make clean` as part of packaging
+override_dh_auto_clean:
+	true
+
+override_dh_auto_build:
+	true
+
+# do not call `make test` as part of packaging
+override_dh_auto_test:
+	true
+
 override_dh_virtualenv:
-	dh_virtualenv --python=/usr/bin/python2.7 --extra-pip-arg='--no-use-wheel'
+	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+    --python=/usr/bin/python2.7 --preinstall no-manylinux1 \
+    --preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/src/nerve_tools/updown_service.py
+++ b/src/nerve_tools/updown_service.py
@@ -82,7 +82,7 @@ def reconfigure_hacheck(service, state, port):
 
     command = [hacheck_command, service]
     if port is not None:
-        command.extend(['-P', port])
+        command.extend(['-P', str(port)])
 
     try:
         subprocess.check_call(command)

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,7 +18,7 @@ setup(
         'environment_tools>=1.1.0,<1.2.0',
         'kazoo>=2.2.0',
         'PyYAML>=3.11',
-        'paasta-tools==0.56.15',
+        'paasta-tools==0.60.1',
         'protobuf==2.6.1',
         'requests>=2.6.2',
         'service-configuration-lib==0.10.1',

--- a/src/tests/updown_service_test.py
+++ b/src/tests/updown_service_test.py
@@ -241,8 +241,8 @@ def test_reconfigure_hacheck():
 
         expected_calls = [
             mock.call(['/usr/bin/hadown', 'test.main']),
-            mock.call(['/usr/bin/hadown', 'test.main', '-P', 1234]),
+            mock.call(['/usr/bin/hadown', 'test.main', '-P', '1234']),
             mock.call(['/usr/bin/haup', 'test.main']),
-            mock.call(['/usr/bin/haup', 'test.main', '-P', 1337]),
+            mock.call(['/usr/bin/haup', 'test.main', '-P', '1337']),
         ]
         assert check_call.call_args_list == expected_calls

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 
 [testenv]
-# wheels for Lucid will not work on Trusty
-install_command = pip install --no-use-wheel --upgrade {opts} {packages}
 basepython=python2.7
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
It turns out that check_call assumes all arguments will be strings
Lovely. This fixes it.