### PR TITLE
configure_nerve generates custom labels

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+nerve-tools (0.14.4) lucid; urgency=low
+
+  * Nerve allows running arbitrary commands to generate custom labels
+
+ -- M Carlson <mcarlson@yelp.com>  Tue, 15 Jun 2017 11:40:33 -0700
+
 nerve-tools (0.14.3) lucid; urgency=low
 
   * Add body aware healthcheck

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -75,6 +75,9 @@ def generate_subconfiguration(
     # hacheck will simply ignore the healthcheck_uri for TCP mode checks
     healthcheck_uri = service_info.get('healthcheck_uri', '/status')
     healthcheck_mode = service_info.get('healthcheck_mode', mode)
+    custom_labels = {}
+    for k, v in service_info.get('custom_labels', {}).items():
+        custom_labels[k] = subprocess.Popen(v.split(), stdout=subprocess.PIPE).communicate()[0].strip()
     hacheck_uri = '/%s/%s/%s/%s' % (
         healthcheck_mode, service_name, healthcheck_port, healthcheck_uri.lstrip('/'))
     advertise = service_info.get('advertise', ['region'])
@@ -175,6 +178,7 @@ def generate_subconfiguration(
                     'weight': weight,
                 }
 
+            config[v2_key]['labels'].update(custom_labels)
             # Set a label that maps the location to an empty string. This
             # allows synapse to find all servers being advertised to it by
             # checking discover_typ:discover_loc == ''

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nerve-tools',
-    version='0.14.3',
+    version='0.14.4',
     provides=['nerve_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
Smartstack.yaml accepts a custom_label key which runs the command in the value and tags it under the key.

* This key will have to be added to the white list of keys in Paasta tools.
* Paasta tools will probably also want to run the command inside the container.