### PR TITLE
Add support for registering k8s services

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -99,21 +99,21 @@ def test_clean_nerve(setup):
 def test_nerve_services(setup):
     expected_services = [
         # HTTP service with extra advertisements
-        'service_three.main.westcoast-dev.region:sjc-dev.1024.new',
-        'service_three.main.westcoast-prod.region:uswest1-prod.1024.new',
+        'service_three.main.westcoast-dev.region:sjc-dev.{}.1024.new'.format(MY_IP_ADDRESS),
+        'service_three.main.westcoast-prod.region:uswest1-prod.{}.1024.new'.format(MY_IP_ADDRESS),
 
         # TCP service
-        'service_one.main.westcoast-dev.region:sjc-dev.1025.new',
+        'service_one.main.westcoast-dev.region:sjc-dev.{}.1025.new'.format(MY_IP_ADDRESS),
 
-        'scribe.main.westcoast-dev.region:sjc-dev.1464.new',
-        'mysql_read.main.westcoast-dev.region:sjc-dev.1464.new',
+        'scribe.main.westcoast-dev.region:sjc-dev.{}.1464.new'.format(MY_IP_ADDRESS),
+        'mysql_read.main.westcoast-dev.region:sjc-dev.{}.1464.new'.format(MY_IP_ADDRESS),
 
         # V2 configs
-        'service_three.main.westcoast-dev:1024.v2.new',
-        'service_three.main.westcoast-prod:1024.v2.new',
-        'service_one.main.westcoast-dev:1025.v2.new',
-        'scribe.main.westcoast-dev:1464.v2.new',
-        'mysql_read.main.westcoast-dev:1464.v2.new',
+        'service_three.main.westcoast-dev:{}.1024.v2.new'.format(MY_IP_ADDRESS),
+        'service_three.main.westcoast-prod:{}.1024.v2.new'.format(MY_IP_ADDRESS),
+        'service_one.main.westcoast-dev:{}.1025.v2.new'.format(MY_IP_ADDRESS),
+        'scribe.main.westcoast-dev:{}.1464.v2.new'.format(MY_IP_ADDRESS),
+        'mysql_read.main.westcoast-dev:{}.1464.v2.new'.format(MY_IP_ADDRESS),
     ]
 
     with open('/etc/nerve/nerve.conf.json') as fd:
@@ -153,7 +153,7 @@ def test_nerve_service_config(setup):
     with open('/etc/nerve/nerve.conf.json') as fd:
         nerve_config = json.load(fd)
     actual_service_entry = \
-        nerve_config['services'].get('service_three.main.westcoast-dev.region:sjc-dev.1024.new')
+        nerve_config['services'].get('service_three.main.westcoast-dev.region:sjc-dev.{}.1024.new'.format(MY_IP_ADDRESS))
 
     assert expected_service_entry == actual_service_entry
 
@@ -191,7 +191,7 @@ def test_v2_nerve_service_config(setup):
     with open('/etc/nerve/nerve.conf.json') as fd:
         nerve_config = json.load(fd)
     actual_service_entry = \
-            nerve_config['services'].get('service_three.main.westcoast-dev:1024.v2.new')
+            nerve_config['services'].get('service_three.main.westcoast-dev:{}.1024.v2.new'.format(MY_IP_ADDRESS))
 
     assert expected_service_entry == actual_service_entry
 

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -148,8 +148,8 @@ def generate_subconfiguration(
             except Exception:
                 continue
 
-            key = '%s.%s.%s:%s.%d.new' % (
-                service_name, zk_location, typ, loc, port,
+            key = '%s.%s.%s:%s.%s.%d.new' % (
+                service_name, zk_location, typ, loc, ip_address, port,
             )
 
             checks_dict = {
@@ -179,8 +179,8 @@ def generate_subconfiguration(
                 'weight': weight,
             }
 
-            v2_key = '%s.%s:%d.v2.new' % (
-                service_name, zk_location, port,
+            v2_key = '%s.%s:%s.%d.v2.new' % (
+                service_name, zk_location, ip_address, port,
             )
 
             if v2_key not in config:

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -26,6 +26,7 @@ from environment_tools.type_utils import get_current_location
 from paasta_tools.marathon_tools import get_marathon_services_running_here_for_nerve
 from paasta_tools.marathon_tools import get_puppet_services_running_here_for_nerve
 from paasta_tools.native_mesos_scheduler import get_paasta_native_services_running_here_for_nerve
+from paasta_tools.kubernetes_tools import get_kubernetes_services_running_here_for_nerve
 from paasta_tools.utils import DEFAULT_SOA_DIR
 
 
@@ -81,6 +82,13 @@ def generate_subconfiguration(
 ):
 
     port = service_info.get('port')
+    # if this is a k8s pod the dict will have the pod IP and we have
+    # an hacheck sidecar in the pod that caches checks otherwise it is
+    # a marathon/puppet etc service and we use the system hacheck
+    hacheck_ip = service_info.get('hacheck_ip', '127.0.0.1')
+    # ditto for the IP of the service, in k8s this is the pod IP,
+    # otherwise we use the hosts IP
+    ip_address = service_info.get('service_ip', ip_address)
 
     mode = service_info.get('mode', 'http')
     healthcheck_timeout_s = service_info.get('healthcheck_timeout_s', 1.0)
@@ -146,7 +154,7 @@ def generate_subconfiguration(
 
             checks_dict = {
                 'type': 'http',
-                'host': '127.0.0.1',
+                'host': hacheck_ip,
                 'port': hacheck_port,
                 'uri': hacheck_uri,
                 'timeout': healthcheck_timeout_s,
@@ -300,6 +308,9 @@ def main():
                 cluster=None,
                 soa_dir=DEFAULT_SOA_DIR,
             ) + get_paasta_native_services_running_here_for_nerve(
+                cluster=None,
+                soa_dir=DEFAULT_SOA_DIR,
+            ) + get_kubernetes_services_running_here_for_nerve(
                 cluster=None,
                 soa_dir=DEFAULT_SOA_DIR,
             )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 environment_tools==1.1.3
-paasta-tools==0.74.8
+paasta-tools==0.75.0
 kazoo==2.2
 PyYAML==3.11
 requests==2.6.2

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,7 +18,7 @@ setup(
         'environment_tools>=1.1.0,<1.2.0',
         'kazoo>=2.2.0',
         'PyYAML>=3.11',
-        'paasta-tools==0.74.8',
+        'paasta-tools==0.75.0',
         'protobuf==2.6.1',
         'requests>=2.6.2',
         'service-configuration-lib==0.12.0',

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 import sys
 import multiprocessing
 from nerve_tools import configure_nerve
@@ -28,7 +29,39 @@ def test_get_named_zookeeper_topology():
     )
 
 
-def test_generate_subconfiguration():
+def get_labels_by_service_and_port(service, port, labels_dir):
+    if (service, port) == ('test_service', 1234):
+        return {'label1': 'value1', 'label2': 'value2'}
+    else:
+        return {}
+
+def get_current_location(typ):
+    return {
+        'ecosystem': 'my_ecosystem',
+        'superregion': 'my_superregion',
+        'habitat': 'my_habitat',
+        'region': 'my_region',
+    }[typ]
+
+def convert_location_type(src_loc, src_typ, dst_typ):
+    if src_typ == dst_typ:
+        return [src_loc]
+    return {
+        ('my_superregion', 'superregion', 'superregion'): ['my_superregion'],
+        ('another_superregion', 'superregion', 'region'): ['another_region'],
+        ('my_region', 'region', 'superregion'): ['my_superregion'],
+        ('another_region', 'region', 'region'): ['another_region'],
+        ('another_region', 'region', 'superregion'): ['another_superregion'],
+    }[(src_loc, src_typ, dst_typ)]
+
+def get_named_zookeeper_topology(cluster_type, cluster_location, zk_topology_dir):
+    return {
+        ('infrastructure', 'my_superregion'): ['1.2.3.4', '2.3.4.5'],
+        ('infrastructure', 'another_superregion'): ['3.4.5.6', '4.5.6.7']
+    }[(cluster_type, cluster_location)]
+
+@pytest.fixture
+def expected_sub_config():
     expected_config = {
         'test_service.my_superregion.region:my_region.1234.new': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
@@ -137,38 +170,10 @@ def test_generate_subconfiguration():
             },
         },
     }
+    return expected_config
 
-    def get_labels_by_service_and_port(service, port, labels_dir):
-        if (service, port) == ('test_service', 1234):
-            return {'label1': 'value1', 'label2': 'value2'}
-        else:
-            return {}
 
-    def get_current_location(typ):
-        return {
-            'ecosystem': 'my_ecosystem',
-            'superregion': 'my_superregion',
-            'habitat': 'my_habitat',
-            'region': 'my_region',
-        }[typ]
-
-    def convert_location_type(src_loc, src_typ, dst_typ):
-        if src_typ == dst_typ:
-            return [src_loc]
-        return {
-            ('my_superregion', 'superregion', 'superregion'): ['my_superregion'],
-            ('another_superregion', 'superregion', 'region'): ['another_region'],
-            ('my_region', 'region', 'superregion'): ['my_superregion'],
-            ('another_region', 'region', 'region'): ['another_region'],
-            ('another_region', 'region', 'superregion'): ['another_superregion'],
-        }[(src_loc, src_typ, dst_typ)]
-
-    def get_named_zookeeper_topology(cluster_type, cluster_location, zk_topology_dir):
-        return {
-            ('infrastructure', 'my_superregion'): ['1.2.3.4', '2.3.4.5'],
-            ('infrastructure', 'another_superregion'): ['3.4.5.6', '4.5.6.7']
-        }[(cluster_type, cluster_location)]
-
+def test_generate_subconfiguration(expected_sub_config):
     with mock.patch(
         'nerve_tools.configure_nerve.get_current_location',
         side_effect=get_current_location
@@ -208,7 +213,57 @@ def test_generate_subconfiguration():
             labels_dir='/dev/null',
         )
 
-    assert expected_config == actual_config
+    assert expected_sub_config == actual_config
+
+
+def test_generate_subconfiguration_k8s(expected_sub_config):
+    with mock.patch(
+        'nerve_tools.configure_nerve.get_current_location',
+        side_effect=get_current_location
+    ), mock.patch(
+        'nerve_tools.configure_nerve.convert_location_type',
+        side_effect=convert_location_type
+    ), mock.patch(
+        'nerve_tools.configure_nerve.get_named_zookeeper_topology',
+        side_effect=get_named_zookeeper_topology
+    ), mock.patch(
+        'nerve_tools.configure_nerve.get_labels_by_service_and_port',
+        side_effect=get_labels_by_service_and_port
+    ):
+
+        for k, v in expected_sub_config.items():
+            expected_sub_config[k]['host'] = '10.4.5.6'
+            for check in expected_sub_config[k]['checks']:
+                check['host'] = '10.1.2.3'
+
+        mock_service_info = {
+            'port': 1234,
+            'routes': [('remote_location', 'local_location')],
+            'healthcheck_timeout_s': 2.0,
+            'healthcheck_mode': 'http',
+            'healthcheck_port': 1234,
+            'hacheck_ip': '10.1.2.3',
+            'service_ip': '10.4.5.6',
+            'advertise': ['region', 'superregion'],
+            'extra_advertise': [
+                ('habitat:my_habitat', 'region:another_region'),
+                ('habitat:your_habitat', 'region:another_region'),  # Ignored
+            ],
+        }
+
+        actual_config = configure_nerve.generate_subconfiguration(
+            service_name='test_service',
+            service_info=mock_service_info,
+            ip_address='ip_address',
+            hacheck_port=6666,
+            weight=mock.sentinel.weight,
+            zk_topology_dir='/fake/path',
+            zk_location_type='superregion',
+            zk_cluster_type='infrastructure',
+            labels_dir='/dev/null',
+        )
+
+    assert expected_sub_config == actual_config
 
 
 def test_generate_configuration_paasta_service():

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -35,6 +35,7 @@ def get_labels_by_service_and_port(service, port, labels_dir):
     else:
         return {}
 
+
 def get_current_location(typ):
     return {
         'ecosystem': 'my_ecosystem',
@@ -42,6 +43,7 @@ def get_current_location(typ):
         'habitat': 'my_habitat',
         'region': 'my_region',
     }[typ]
+
 
 def convert_location_type(src_loc, src_typ, dst_typ):
     if src_typ == dst_typ:
@@ -54,16 +56,18 @@ def convert_location_type(src_loc, src_typ, dst_typ):
         ('another_region', 'region', 'superregion'): ['another_superregion'],
     }[(src_loc, src_typ, dst_typ)]
 
+
 def get_named_zookeeper_topology(cluster_type, cluster_location, zk_topology_dir):
     return {
         ('infrastructure', 'my_superregion'): ['1.2.3.4', '2.3.4.5'],
         ('infrastructure', 'another_superregion'): ['3.4.5.6', '4.5.6.7']
     }[(cluster_type, cluster_location)]
 
+
 @pytest.fixture
 def expected_sub_config():
     expected_config = {
-        'test_service.my_superregion.region:my_region.1234.new': {
+        'test_service.my_superregion.region:my_region.ip_address.1234.new': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/nerve/region:my_region/test_service',
             'checks': [{
@@ -82,7 +86,7 @@ def expected_sub_config():
             'port': 1234,
             'weight': mock.sentinel.weight,
         },
-        'test_service.my_superregion.superregion:my_superregion.1234.new': {
+        'test_service.my_superregion.superregion:my_superregion.ip_address.1234.new': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/nerve/superregion:my_superregion/test_service',
             'checks': [{
@@ -101,7 +105,7 @@ def expected_sub_config():
             'port': 1234,
             'weight': mock.sentinel.weight,
         },
-        'test_service.another_superregion.region:another_region.1234.new': {
+        'test_service.another_superregion.region:another_region.ip_address.1234.new': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/nerve/region:another_region/test_service',
             'checks': [{
@@ -120,7 +124,7 @@ def expected_sub_config():
             'port': 1234,
             'weight': mock.sentinel.weight,
         },
-        'test_service.my_superregion:1234.v2.new': {
+        'test_service.my_superregion:ip_address.1234.v2.new': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/smartstack/global/test_service',
             'checks': [{
@@ -145,7 +149,7 @@ def expected_sub_config():
                 'superregion:my_superregion': '',
             },
         },
-        'test_service.another_superregion:1234.v2.new': {
+        'test_service.another_superregion:ip_address.1234.v2.new': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/smartstack/global/test_service',
             'checks': [{
@@ -235,6 +239,9 @@ def test_generate_subconfiguration_k8s(expected_sub_config):
             expected_sub_config[k]['host'] = '10.4.5.6'
             for check in expected_sub_config[k]['checks']:
                 check['host'] = '10.1.2.3'
+        new_expected_sub_config = {}
+        for k, v in expected_sub_config.items():
+            new_expected_sub_config[k.replace('ip_address', '10.4.5.6')] = expected_sub_config[k]
 
         mock_service_info = {
             'port': 1234,
@@ -263,7 +270,7 @@ def test_generate_subconfiguration_k8s(expected_sub_config):
             labels_dir='/dev/null',
         )
 
-    assert expected_sub_config == actual_config
+    assert new_expected_sub_config == actual_config
 
 
 def test_generate_configuration_paasta_service():


### PR DESCRIPTION
Adds a new call to get kubernetes services from paasta_tools.

Adds two new options to the service_info dict to allow us to override
the host IP and the check IP. For kubernetes we initially want the pod
IP for both and may later want a system level hacheck again.

NB: I haven't published the paasta_tools branch with `get_kubernetes_services_running_here_for_nerve` yet. So I will have to merge that first and update the paasta_tools version here before the tests pass.