### PR TITLE
Fix bytes vs str in DictReader

### DIFF
--- a/src/nerve_tools/updown_service.py
+++ b/src/nerve_tools/updown_service.py
@@ -1,6 +1,7 @@
 # Utility to change local SmartStack service state
 
 import csv
+import io
 import os
 import socket
 import subprocess
@@ -112,9 +113,13 @@ def check_haproxy_state(service, expected_state):
         # Allow for transient errors when querying HAProxy
         return False
 
+    # urlopen returns a byte stream but DictReader expects an
+    # iterable of strs. So we decode the file to a str and pass
+    # it to StringIO to get a file like object that is csv.DictReader
+    # friendly
+    csv_file = io.StringIO(fd.read().decode())
     host = '%s:' % get_my_ip_address()
-    reader = csv.DictReader(fd, delimiter=',')
-
+    reader = csv.DictReader(csv_file, delimiter=',')
     entries = list(reader)
     entries = [entry for entry in entries if service == entry['# pxname']]
 

--- a/src/tests/updown_service_test.py
+++ b/src/tests/updown_service_test.py
@@ -71,7 +71,7 @@ def test_check_haproxy_state():
     for test in tests:
         my_ip_address, expected_state, expected_result = test
 
-        with open(mock_stats_path) as fd:
+        with open(mock_stats_path, 'rb') as fd:
             with mock.patch(
                 'urllib.request.urlopen', return_value=fd
             ), mock.patch(
@@ -87,7 +87,7 @@ def test_check_haproxy_state():
 def test_wait_for_haproxy_with_healthcheck_pass_returns_zero():
     mock_stats_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), 'haproxy_stats.csv')
-    with open(mock_stats_path) as fd:
+    with open(mock_stats_path, 'rb') as fd:
         with mock.patch(
             'urllib.request.urlopen', return_value=fd
         ), mock.patch(
@@ -106,7 +106,7 @@ def test_wait_for_haproxy_with_healthcheck_fail_returns_one():
 
     with mock.patch(
         'urllib.request.urlopen',
-        side_effect=lambda _, timeout: open(mock_stats_path)
+        side_effect=lambda _, timeout: open(mock_stats_path, 'rb')
     ), mock.patch(
         'time.sleep'
     ), mock.patch(
@@ -152,7 +152,7 @@ def test_unknown_service():
     mock_stats_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), 'haproxy_stats.csv')
 
-    with open(mock_stats_path) as fd:
+    with open(mock_stats_path, 'rb') as fd:
         with mock.patch(
             'urllib.request.urlopen',
             return_value=fd


### PR DESCRIPTION
This was causing updown_service to fail when getting and reading the
HAProxy stats csv. Unfortunately this is a pain to itest because we
don't have haproxy in the itest setup. I have confirmend the fix by
testing against a local haproxy.