### PR TITLE
Write the deploy_group and paasta_instance to nerve config

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 environment_tools==1.1.3
-paasta-tools==0.83.2
+paasta-tools==0.84.19
 kazoo==2.2
 PyYAML==3.11
 requests==2.6.2

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -145,8 +145,10 @@ def expected_sub_config():
             'labels': {
                 'label1': 'value1',
                 'label2': 'value2',
-                'region:my_region': '',
                 'superregion:my_superregion': '',
+                'region:my_region': '',
+                'deploy_group': 'prod.canary',
+                'paasta_instance': 'canary',
             },
         },
         'test_service.another_superregion:ip_address.1234.v2.new': {
@@ -171,6 +173,8 @@ def expected_sub_config():
                 'label1': 'value1',
                 'label2': 'value2',
                 'region:another_region': '',
+                'deploy_group': 'prod.canary',
+                'paasta_instance': 'canary',
             },
         },
     }
@@ -203,6 +207,8 @@ def test_generate_subconfiguration(expected_sub_config):
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
             ],
+            'deploy_group': 'prod.canary',
+            'paasta_instance': 'canary',
         }
 
         actual_config = configure_nerve.generate_subconfiguration(
@@ -256,6 +262,8 @@ def test_generate_subconfiguration_k8s(expected_sub_config):
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
             ],
+            'deploy_group': 'prod.canary',
+            'paasta_instance': 'canary',
         }
 
         actual_config = configure_nerve.generate_subconfiguration(


### PR DESCRIPTION
This is part 2 of CORESERV-7915 (internal ticket). The code here requires the [changes I made in PaaSTA](https://github.com/Yelp/paasta/pull/2258) to work, that I released yesterday, before bumping the requirements to `paasta-tools==0.84.19`.

Again, added some optional data to be passed along with service registrations. If the data isn't there, it simply won't be written. Added extra fields to the testing logic and that's pretty much it.