### PR TITLE
Read envoy listeners from /listeners and healthcheck paasta services through envoy

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -6,6 +6,6 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True
 disallow_any_decorated = True
-disallow_any_explicit = True
+disallow_any_explicit = False
 disallow_any_generics = True
 warn_unused_ignores = True

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -6,6 +6,6 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True
 disallow_any_decorated = True
-disallow_any_explicit = False
+disallow_any_explicit = True
 disallow_any_generics = True
 warn_unused_ignores = True

--- a/src/nerve_tools/clean_nerve.py
+++ b/src/nerve_tools/clean_nerve.py
@@ -14,7 +14,7 @@ import argparse
 import kazoo.client
 import kazoo.exceptions
 import yaml
-from yaml import CLoader  # type: ignore
+from yaml import CLoader
 
 
 # CEP 355 Zookeepers

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -23,7 +23,6 @@ import time
 import sys
 import yaml
 from yaml import CSafeLoader  # type: ignore
-from typing import Any
 from typing import cast
 from typing import Dict
 from typing import Iterable
@@ -82,7 +81,7 @@ def get_labels_by_service_and_port(
     service_name: str,
     port: int,
     labels_dir: str = DEFAULT_LABEL_DIR,
-) -> Dict[str, str]:
+) -> MutableMapping[str, str]:
     custom_labels: Dict[str, str] = {}
     try:
         path = os.path.join(labels_dir, service_name + str(port) + '*')
@@ -176,7 +175,7 @@ def generate_envoy_configuration(
     hacheck_port: int,
     ip_address: str,
     zookeeper_topology: Iterable[str],
-    custom_labels: Dict[str, str],
+    custom_labels: MutableMapping[str, str],
     weight: int,
     deploy_group: Optional[str],
     paasta_instance: Optional[str],
@@ -394,7 +393,7 @@ def generate_configuration(
     zk_location_type: str,
     zk_cluster_type: str,
     labels_dir: str,
-    envoy_listeners: Dict[str, int],
+    envoy_listeners: Mapping[str, int],
 ) -> NerveConfig:
     nerve_config: NerveConfig = {
         'instance_id': get_hostname(),

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -144,7 +144,17 @@ class ServiceInfo(TypedDict):
     deploy_group: Optional[str]
 
 
-def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[Mapping]]:
+class ListenerAddress(TypedDict):
+    address: str
+    port_value: int
+
+
+class ListenerConfig(TypedDict):
+    name: str
+    local_address: Dict[str, ListenerAddress]
+
+
+def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[ListenerConfig]]:
     try:
         return requests.get(f'http://localhost:{admin_port}/listeners?format=json').json()
     except Exception as e:

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -455,13 +455,13 @@ def generate_configuration(
                 'healthcheck_port': envoy_ingress_port,
                 'extra_healthcheck_headers': healthcheck_headers,
             })
-            envoy_service_info = cast(ServiceInfo, service_info_copy)
+            envoy_service_info = cast(Optional[ServiceInfo], service_info_copy)
 
         update_subconfiguration_for_here(
             service_name=service_name,
             service_info=cast(ServiceInfo, service_info),
             service_weight=10,
-            envoy_service_info=cast(Optional[ServiceInfo], envoy_service_info),
+            envoy_service_info=envoy_service_info,
         )
 
     return nerve_config

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -445,6 +445,7 @@ def generate_configuration(
                 'healthcheck_port': envoy_ingress_port,
                 'extra_healthcheck_headers': healthcheck_headers,
             })
+            envoy_service_info = cast(ServiceInfo, service_info_copy)
 
         update_subconfiguration_for_here(
             service_name=service_name,

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -337,6 +337,10 @@ def generate_subconfiguration(
                         'labels': custom_labels,
                         'weight': weight,
                     }
+                    if deploy_group:
+                        config[envoy_key]['labels']['deploy_group'] = deploy_group
+                    if paasta_instance:
+                        config[envoy_key]['labels']['paasta_instance'] = paasta_instance
 
     return config
 

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -22,7 +22,7 @@ import subprocess
 import time
 import sys
 import yaml
-from yaml import CSafeLoader  # type: ignore
+from yaml import CSafeLoader
 from typing import cast
 from typing import Dict
 from typing import Iterable
@@ -189,7 +189,8 @@ def _get_envoy_service_info(
     if envoy_listeners and envoy_key in envoy_listeners:
         service_info_copy = copy.deepcopy(service_info)
         envoy_ingress_port = envoy_listeners[envoy_key]
-        healthcheck_headers = service_info_copy.get('extra_healthcheck_headers', {})
+        healthcheck_headers: Dict[str, str] = {}
+        healthcheck_headers.update(service_info_copy.get('extra_healthcheck_headers', {}))
         healthcheck_headers['Host'] = service_name
         service_info_copy.update({
             'port': envoy_ingress_port,
@@ -244,7 +245,7 @@ def generate_envoy_configuration(
         checks=[
             checks_dict,
         ],
-        labels=custom_labels,
+        labels=cast(Dict[str, str], custom_labels),
         weight=weight,
     )
 
@@ -461,7 +462,7 @@ def generate_configuration(
             service_weight=weight,
             envoy_service_info=_get_envoy_service_info(
                 service_name=service_name,
-                service_info=service_info,
+                service_info=cast(ServiceInfo, service_info),
                 envoy_listeners=envoy_listeners,
             ),
         )
@@ -472,7 +473,7 @@ def generate_configuration(
             service_weight=10,
             envoy_service_info=_get_envoy_service_info(
                 service_name=service_name,
-                service_info=service_info,
+                service_info=cast(ServiceInfo, service_info),
                 envoy_listeners=envoy_listeners,
             ),
         )

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -27,6 +27,7 @@ from typing import cast
 from typing import Dict
 from typing import Iterable
 from typing import Mapping
+from typing import MutableMapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -154,13 +155,13 @@ def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[Ma
 def get_envoy_listeners(admin_port: int) -> Mapping[str, int]:
     envoy_listeners: Dict[str, int] = {}
     envoy_listener_config = _get_envoy_listeners_from_admin(admin_port)
-    for listener in envoy_listener_config['listener_statuses']:
+    for listener in envoy_listener_config.get('listener_statuses', []):
         result = INGRESS_LISTENER_REGEX.match(listener['name'])
         if result:
             service_name = result.group('service_name')
             local_host_port = result.group('port')
             envoy_listeners[f'{service_name}.{local_host_port}'] = \
-                int(listener_config['address']['socket_address']['port_value'])
+                int(listener['local_address']['socket_address']['port_value'])
     return envoy_listeners
 
 

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -433,25 +433,24 @@ def generate_configuration(
             envoy_service_info=None,
         )
     for (service_name, service_info) in paasta_services:
+        envoy_service_info: Optional[ServiceInfo] = None
         envoy_key = f"{service_name}.{service_info['port']}"
         if envoy_listeners and envoy_key in envoy_listeners:
-            envoy_service_info = copy.deepcopy(service_info)
+            service_info_copy = copy.deepcopy(service_info)
             envoy_ingress_port = envoy_listeners[envoy_key]
-            healthcheck_headers = envoy_service_info.get('extra_healthcheck_headers', {})
+            healthcheck_headers = service_info_copy.get('extra_healthcheck_headers', {})
             healthcheck_headers['Host'] = service_name
-            envoy_service_info.update({
+            service_info_copy.update({
                 'port': envoy_ingress_port,
                 'healthcheck_port': envoy_ingress_port,
                 'extra_healthcheck_headers': healthcheck_headers,
             })
-        else:
-            envoy_service_info = None
 
         update_subconfiguration_for_here(
             service_name=service_name,
             service_info=cast(ServiceInfo, service_info),
             service_weight=10,
-            envoy_service_info=envoy_service_info,
+            envoy_service_info=cast(Optional[ServiceInfo], envoy_service_info),
         )
 
     return nerve_config

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -507,7 +507,7 @@ def main() -> None:
     opts = parse_args(sys.argv[1:])
     new_config = generate_configuration(
         paasta_services=(
-            get_marathon_services_running_here_for_nerve(
+            get_marathon_services_running_here_for_nerve(  # type: ignore
                 cluster=None,
                 soa_dir=DEFAULT_SOA_DIR,
             ) + get_paasta_native_services_running_here_for_nerve(

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -170,8 +170,12 @@ def get_envoy_listeners(admin_port: int) -> Mapping[str, int]:
         if result:
             service_name = result.group('service_name')
             local_host_port = result.group('port')
-            envoy_listeners[f'{service_name}.{local_host_port}'] = \
-                int(listener['local_address']['socket_address']['port_value'])
+            try:
+                envoy_listeners[f'{service_name}.{local_host_port}'] = \
+                    int(listener['local_address']['socket_address']['port_value'])
+            except KeyError:
+                # If there is no socket_address and port_value, skip this listener
+                pass
     return envoy_listeners
 
 

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -185,7 +185,7 @@ def expected_sub_config():
 @pytest.fixture
 def expected_sub_config_with_envoy_listeners(expected_sub_config):
     expected_sub_config.update({
-        'test_service.my_superregion:ip_address.1234.envoy': {
+        'test_service.my_superregion:ip_address.1234': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/envoy/global/test_service',
             'checks': [{
@@ -210,7 +210,7 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
                 'paasta_instance': 'canary',
             },
         },
-        'test_service.another_superregion:ip_address.1234.envoy': {
+        'test_service.another_superregion:ip_address.1234': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/envoy/global/test_service',
             'checks': [{

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -243,28 +243,22 @@ def test_get_envoy_listeners():
     expected_envoy_listeners = {
         'test_service.main.1234': 54321,
     }
-    mock_config_dump_return_value = {
-        'configs': [
+    mock_envoy_admin_listeners_return_value = {
+        'listener_statuses': [
             {
-                'dynamic_active_listeners': [
-                    {
-                        'listener': {
-                            'name': 'test_service.main.1234.ingress_listener',
-                            'address': {
-                                'socket_address': {
-                                    'address': '0.0.0.0',
-                                    'port_value': 54321,
-                                }
-                            }
-                        }
-                    }
-                ],
-            }
+                'name': 'test_service.main.1234.ingress_listener',
+                'local_address': {
+                    'socket_address': {
+                        'address': '0.0.0.0',
+                        'port_value': 54321,
+                    },
+                },
+            },
         ],
     }
     with mock.patch(
-        'nerve_tools.configure_nerve._get_envoy_config_dump',
-        return_value=mock_config_dump_return_value,
+        'nerve_tools.configure_nerve._get_envoy_listeners_from_admin',
+        return_value=mock_envoy_admin_listeners_return_value,
     ):
         assert configure_nerve.get_envoy_listeners(123) == \
             expected_envoy_listeners

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -203,7 +203,12 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
             'check_interval': 3.0,
             'port': 35000,
             'weight': mock.sentinel.weight,
-            'labels': {'label1': 'value1', 'label2': 'value2'},
+            'labels': {
+                'label1': 'value1',
+                'label2': 'value2',
+                'deploy_group': 'prod.canary',
+                'paasta_instance': 'canary',
+            },
         },
         'test_service.another_superregion:ip_address.1234.envoy': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
@@ -223,7 +228,12 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
             'check_interval': 3.0,
             'port': 35000,
             'weight': mock.sentinel.weight,
-            'labels': {'label1': 'value1', 'label2': 'value2'},
+            'labels': {
+                'label1': 'value1',
+                'label2': 'value2',
+                'deploy_group': 'prod.canary',
+                'paasta_instance': 'canary',
+            },
         },
     })
     return expected_sub_config
@@ -396,6 +406,8 @@ def test_generate_subconfiguration_with_envoy_listeners(expected_sub_config_with
                 ('habitat:my_habitat', 'region:another_region'),
                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
             ],
+            'deploy_group': 'prod.canary',
+            'paasta_instance': 'canary',
         }
         mock_envoy_service_info = copy.deepcopy(mock_service_info)
         mock_envoy_service_info.update({

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -22,7 +22,7 @@ max-line-length = 120
 basepython = python3.6
 deps =
     {[testenv]deps}
-    mypy==0.641
+    mypy==0.701
 setenv =
     MYPYPATH = {toxinidir}
 whitelist_externals =


### PR DESCRIPTION
If ingress listeners for locally running paasta services are set up in Envoy, configure_nerve will read the listeners info from Envoy admin's /listener endpoint and output nerve configs for the Envoy ingress endpoints.

The nerve configs for the Envoy listener endpoints should be the same as the .v2 configs except for
* different port numbers
* different zookeeper path (/envoy/global/{service name})