### PR TITLE
Bump pyyaml and requests versions because of the security alert

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,8 +2,8 @@ argparse==1.2.1
 environment_tools==1.1.3
 paasta-tools==0.84.19
 kazoo==2.2
-PyYAML==3.11
-requests==2.6.2
+PyYAML==4.2b1
+requests==2.20.0
 service-configuration-lib==0.12.0
 setuptools==33.1.1
 dulwich==0.17.3


### PR DESCRIPTION
Bump `pyyaml` to 4.2b1 and `requests` to 2.20.0 because of the security
alert.