### PR TITLE
Ignore mypy when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ deploy:
     on:
       branch: master
       repo: Yelp/nerve-tools
+      condition: $MAKE_TARGET =~ ^itest_


### PR DESCRIPTION
Same issue as https://github.com/Yelp/synapse-tools/pull/68

Master branch travisCI build is failing for the mypy target:

```
mypy run-test: commands[0] | mypy nerve_tools
___________________________________ summary ____________________________________
  mypy: commands succeeded
  congratulations :)
The command "make "$MAKE_TARGET"" exited with 0.
dpl_0
1.66s$ rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl
Fetching dpl-1.10.11.gem
Successfully installed dpl-1.10.11
Parsing documentation for dpl-1.10.11
Installing ri documentation for dpl-1.10.11
Done installing documentation for dpl after 0 seconds
1 gem installed
dpl.1
Installing deploy dependencies
Fetching dpl-bintray-1.10.11.gem
Successfully installed dpl-bintray-1.10.11
Parsing documentation for dpl-bintray-1.10.11
Installing ri documentation for dpl-bintray-1.10.11
Done installing documentation for dpl-bintray after 0 seconds
1 gem installed
dpl.2
Preparing deploy
[Bintray Upload] Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup.
Saved working directory and index state WIP on (no branch): 7eca88c Released 0.16.0 via make release
dpl.3
Deploying application
[Bintray Upload] Reading descriptor file: bintray.json
Already up to date!
HEAD detached at 7eca88c
nothing to commit, working tree clean
Dropped refs/stash@{0} (699e85ba17ae8f25aab52ecc08d6c022dd9e612f)
/home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-bintray-1.10.11/lib/dpl/provider/bintray.rb:45:in `read': No such file or directory @ rb_sysopen - bintray.json (Errno::ENOENT)
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-bintray-1.10.11/lib/dpl/provider/bintray.rb:45:in `read_descriptor'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-bintray-1.10.11/lib/dpl/provider/bintray.rb:431:in `push_app'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/lib/dpl/provider.rb:199:in `block in deploy'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/lib/dpl/cli.rb:41:in `fold'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/lib/dpl/provider.rb:199:in `deploy'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/lib/dpl/cli.rb:32:in `run'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/lib/dpl/cli.rb:7:in `run'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/dpl-1.10.11/bin/dpl:5:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/dpl:23:in `load'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/dpl:23:in `<main>'
failed to deploy
```

The fix is to make travisCI ignore the mypy target.