### PR TITLE
Use HTTPs (when applicable) for ingress envoy healthchecks

### DIFF
--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -217,7 +217,7 @@ def generate_envoy_configuration(
     healthcheck_port = envoy_service_info['port']
     healthcheck_uri = envoy_service_info.get('healthcheck_uri', '/status')
     # healthchecks via envoy for `http` services should be made via `https`.
-    healthcheck_mode = 'https' if healthcheck_mode == 'http' else healtcheck_mode
+    healthcheck_mode = 'https' if healthcheck_mode == 'http' else healthcheck_mode
     envoy_hacheck_uri = \
         f"/{healthcheck_mode}/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
     healthcheck_timeout_s = envoy_service_info.get('healthcheck_timeout_s', 1.0)

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -217,7 +217,7 @@ def generate_envoy_configuration(
     healthcheck_port = envoy_service_info['port']
     healthcheck_uri = envoy_service_info.get('healthcheck_uri', '/status')
     envoy_hacheck_uri = \
-        f"/{healthcheck_mode}/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
+        f"/https/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
     healthcheck_timeout_s = envoy_service_info.get('healthcheck_timeout_s', 1.0)
     checks_dict: CheckDict = {
         'type': 'http',

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -216,8 +216,10 @@ def generate_envoy_configuration(
     # hacheck healthchecks through envoy
     healthcheck_port = envoy_service_info['port']
     healthcheck_uri = envoy_service_info.get('healthcheck_uri', '/status')
+    # healthchecks via envoy for `http` services should be made via `https`.
+    healthcheck_mode = 'https' if healthcheck_mode == 'http' else healtcheck_mode
     envoy_hacheck_uri = \
-        f"/https/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
+        f"/{healthcheck_mode}/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
     healthcheck_timeout_s = envoy_service_info.get('healthcheck_timeout_s', 1.0)
     checks_dict: CheckDict = {
         'type': 'http',

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -190,7 +190,7 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
             'zk_path': '/envoy/global/test_service',
             'checks': [{
                 'rise': 1,
-                'uri': '/http/test_service/35000/status',
+                'uri': '/https/test_service/35000/status',
                 'host': '127.0.0.1',
                 'timeout': 2.0,
                 'open_timeout': 2.0,
@@ -215,7 +215,7 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
             'zk_path': '/envoy/global/test_service',
             'checks': [{
                 'rise': 1,
-                'uri': '/http/test_service/35000/status',
+                'uri': '/https/test_service/35000/status',
                 'host': '127.0.0.1',
                 'timeout': 2.0,
                 'open_timeout': 2.0,


### PR DESCRIPTION
Uses HTTPS to healthcheck HTTP services which are proxied via envoy. The testing refactor of meshd is still in progress which is making testing this change difficult. Shipping this PR since unhackathon is over and it might be some time before I am able to complete the testing refactor. 