### PR TITLE
Fix multiple smartstack registrations

### DIFF
--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -53,7 +53,7 @@ except NotImplementedError:
 
 DEFAULT_LABEL_DIR = '/etc/nerve/labels.d/'
 
-INGRESS_LISTENER_REGEX = re.compile(r'^(?P<service_name>\S+\.\S+)\.(?P<port>\d+)\.ingress_listener$')
+INGRESS_LISTENER_REGEX = re.compile(r'^\S+\.\S+\.(?P<port>\d+)\.ingress_listener$')
 
 
 def get_hostname() -> str:
@@ -162,16 +162,20 @@ def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[Li
         return {}
 
 
-def get_envoy_listeners(admin_port: int) -> Mapping[str, int]:
-    envoy_listeners: Dict[str, int] = {}
+def get_envoy_listeners(admin_port: int) -> Mapping[int, int]:
+    """Compile a mapping of "service's local listening port" -> "the corresponding Envoy
+    ingress port".
+
+    This will be used to determine the Envoy ingress port for a given service's actual port.
+    """
+    envoy_listeners: Dict[int, int] = {}
     envoy_listener_config = _get_envoy_listeners_from_admin(admin_port)
     for listener in envoy_listener_config.get('listener_statuses', []):
         result = INGRESS_LISTENER_REGEX.match(listener['name'])
         if result:
-            service_name = result.group('service_name')
             local_host_port = result.group('port')
             try:
-                envoy_listeners[f'{service_name}.{local_host_port}'] = \
+                envoy_listeners[int(local_host_port)] = \
                     int(listener['local_address']['socket_address']['port_value'])
             except KeyError:
                 # If there is no socket_address and port_value, skip this listener
@@ -182,13 +186,16 @@ def get_envoy_listeners(admin_port: int) -> Mapping[str, int]:
 def _get_envoy_service_info(
     service_name: str,
     service_info: ServiceInfo,
-    envoy_listeners: Mapping[str, int],
+    envoy_listeners: Mapping[int, int],
 ) -> Optional[ServiceInfo]:
     envoy_service_info: Optional[ServiceInfo] = None
-    envoy_key = f"{service_name}.{service_info['port']}"
-    if envoy_listeners and envoy_key in envoy_listeners:
+    local_host_port = service_info['port']
+    # If this service's local host port is being routed to from an Envoy ingress port,
+    # then output nerve configs so that this service will be healthchecked through
+    # the Envoy ingress port. This requires setting the healthcheck Host header too.
+    if envoy_listeners and local_host_port in envoy_listeners:
         service_info_copy = copy.deepcopy(service_info)
-        envoy_ingress_port = envoy_listeners[envoy_key]
+        envoy_ingress_port = envoy_listeners[local_host_port]
         healthcheck_headers: Dict[str, str] = {}
         healthcheck_headers.update(service_info_copy.get('extra_healthcheck_headers', {}))
         healthcheck_headers['Host'] = service_name
@@ -424,7 +431,7 @@ def generate_configuration(
     zk_location_type: str,
     zk_cluster_type: str,
     labels_dir: str,
-    envoy_listeners: Mapping[str, int],
+    envoy_listeners: Mapping[int, int],
 ) -> NerveConfig:
     nerve_config: NerveConfig = {
         'instance_id': get_hostname(),

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -548,7 +548,6 @@ def test_generate_configuration_paasta_service_with_envoy_listeners():
             envoy_listeners=envoy_listeners,
         )
 
-    # assert_has_calls
         mock_generate_subconfiguration.assert_has_calls([
             mock.call(
                 service_name='test_service.main',


### PR DESCRIPTION
Just check that an Envoy ingress port is set up for a local service's actual port when determining whether we should output Envoy nerve configs for a service. This ensures that services with multiple registrations will have all the registrations healthchecked.

Previously, a mapping of "{service_name}.{service_instance}.{local_host_port}" -> "Envoy ingress port" was used, but this would cause services with multiple registrations (like "service.main" and "service.alt_name") to only have one Envoy nerve config outputted. This is because Envoy's `/listeners` admin endpoint only outputs listener information under the listener name, and only one listener is set up for each service, even if it has multiple registrations.

By only checking the local host port, we lose some guarantees that the nerve configs will match the service name and instance. This can be a problem if another service gets assigned the same local host port by marathon after configure_nerve.py has already read information about locally running services, but the good thing is that healthchecks through Envoy require the correct `Host` header to be set, so in this case, the healthchecks will fail and the wrong service will never be registered in ZooKeeper. The next configure_nerve.py run will pick up the right information about locally running services and output the right Envoy nerve configs.