### PR TITLE
Bump paasta to 0.90.4

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 environment_tools==1.1.3
-paasta-tools==0.84.19
+paasta-tools==0.90.4
 kazoo==2.2
 PyYAML==4.2b1
 requests==2.20.0


### PR DESCRIPTION
We've changed some kubernetes labels and need nerve to stop reading old ones.