### PR TITLE
Add envoy ingress listeners to nerve.conf.json for kubernetes services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ nerve-tools*.changes
 nerve-tools*.ddeb
 nerve-tools*.dsc
 nerve-tools*.tar.gz
+src/.coverage
+src/.pytest_cache
 src/build
 src/debian/.debhelper
 src/debian/debhelper-build-stamp

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,7 @@
+.PHONY: help
+help:  ## You're looking at it
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: test
+test:  ## Run unit tests
+	tox -e xenial

--- a/src/nerve_tools/config.py
+++ b/src/nerve_tools/config.py
@@ -1,0 +1,66 @@
+from mypy_extensions import TypedDict
+from typing import Mapping
+from typing import Iterable
+from typing import Dict
+from typing import Tuple
+from typing import Optional
+
+
+class CheckDict(TypedDict, total=False):
+    type: str
+    host: str
+    port: int
+    uri: str
+    timeout: float
+    open_timeout: float
+    rise: int
+    fall: int
+    headers: Mapping[str, str]
+    expect: str
+
+
+class SubSubConfiguration(TypedDict, total=False):
+    port: int
+    host: str
+    zk_hosts: Iterable[str]
+    zk_path: str
+    check_interval: float
+    checks: Iterable[CheckDict]
+    labels: Dict[str, str]
+    weight: int
+
+
+SubConfiguration = Dict[str, SubSubConfiguration]
+
+
+class NerveConfig(TypedDict):
+    instance_id: str
+    services: SubConfiguration
+    heartbeat_path: str
+
+
+class ServiceInfo(TypedDict):
+    port: int
+    hacheck_ip: str
+    service_ip: str
+    mode: str
+    healthcheck_timeout_s: int
+    healthcheck_port: int
+    healthcheck_uri: str
+    healthcheck_mode: str
+    advertise: Iterable[str]
+    extra_advertise: Iterable[Tuple[str, str]]
+    extra_healthcheck_headers: Mapping[str, str]
+    healthcheck_body_expect: str
+    paasta_instance: Optional[str]
+    deploy_group: Optional[str]
+
+
+class ListenerAddress(TypedDict):
+    address: str
+    port_value: int
+
+
+class ListenerConfig(TypedDict):
+    name: str
+    local_address: Dict[str, ListenerAddress]

--- a/src/nerve_tools/config.py
+++ b/src/nerve_tools/config.py
@@ -39,7 +39,7 @@ class NerveConfig(TypedDict):
     heartbeat_path: str
 
 
-class ServiceInfo(TypedDict):
+class ServiceInfo(TypedDict, total=False):
     port: int
     hacheck_ip: str
     service_ip: str
@@ -54,6 +54,7 @@ class ServiceInfo(TypedDict):
     healthcheck_body_expect: str
     paasta_instance: Optional[str]
     deploy_group: Optional[str]
+    host: str
 
 
 class ListenerAddress(TypedDict):

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -245,7 +245,7 @@ def generate_configuration(
     zk_location_type: str,
     zk_cluster_type: str,
     labels_dir: str,
-    envoy_ingress_listeners: Mapping[int, int],
+    envoy_ingress_listeners: Mapping[Tuple[str, int], int],
 ) -> NerveConfig:
     nerve_config: NerveConfig = {
         'instance_id': get_hostname(),

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -43,7 +43,7 @@ from nerve_tools.config import NerveConfig
 from nerve_tools.config import ServiceInfo
 from nerve_tools.config import SubConfiguration
 from nerve_tools.envoy import get_envoy_ingress_listeners
-from nerve_tools.envoy import _get_envoy_service_info
+from nerve_tools.envoy import get_envoy_service_info
 from nerve_tools.envoy import generate_envoy_subsubconfiguration
 from nerve_tools.util import get_hostname
 from nerve_tools.util import get_host_ip
@@ -281,7 +281,7 @@ def generate_configuration(
             service_name=service_name,
             service_info=cast(ServiceInfo, service_info),
             service_weight=weight,
-            envoy_service_info=_get_envoy_service_info(
+            envoy_service_info=get_envoy_service_info(
                 service_name=service_name,
                 service_info=cast(ServiceInfo, service_info),
                 envoy_ingress_listeners=envoy_ingress_listeners,
@@ -293,7 +293,7 @@ def generate_configuration(
             service_name=service_name,
             service_info=cast(ServiceInfo, service_info),
             service_weight=10,
-            envoy_service_info=_get_envoy_service_info(
+            envoy_service_info=get_envoy_service_info(
                 service_name=service_name,
                 service_info=cast(ServiceInfo, service_info),
                 envoy_ingress_listeners=envoy_ingress_listeners,

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -49,7 +49,7 @@ def get_envoy_ingress_listeners(admin_port: int) -> Mapping[int, int]:
     return envoy_listeners
 
 
-def _get_envoy_service_info(
+def get_envoy_service_info(
     service_name: str,
     service_info: ServiceInfo,
     envoy_ingress_listeners: Mapping[int, int],

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -1,0 +1,138 @@
+import copy
+import logging
+import re
+from typing import cast
+from typing import Mapping
+from typing import Iterable
+from typing import Optional
+from typing import Dict
+
+import requests
+
+from nerve_tools.config import CheckDict
+from nerve_tools.config import ListenerConfig
+from nerve_tools.config import ServiceInfo
+from nerve_tools.config import SubSubConfiguration
+from nerve_tools.util import get_ip_address
+
+
+INGRESS_LISTENER_REGEX = re.compile(r'^\S+\.\S+\.(?P<port>\d+)\.ingress_listener$')
+
+
+def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[ListenerConfig]]:
+    try:
+        return requests.get(f'http://localhost:{admin_port}/listeners?format=json').json()
+    except Exception as e:
+        logging.warning(f'Unable to get envoy listeners: {e}')
+        return {}
+
+
+def get_envoy_ingress_listeners(admin_port: int) -> Mapping[int, int]:
+    """Compile a mapping of "service's local listening port" -> "the corresponding Envoy
+    ingress port".
+
+    This will be used to determine the Envoy ingress port for a given service's actual port.
+    """
+    envoy_listeners: Dict[int, int] = {}
+    envoy_listeners_config = _get_envoy_listeners_from_admin(admin_port)
+
+    for listener in envoy_listeners_config.get('listener_statuses', []):
+        result = INGRESS_LISTENER_REGEX.match(listener['name'])
+        if result:
+            local_host_port = result.group('port')
+            try:
+                envoy_listeners[int(local_host_port)] = \
+                    int(listener['local_address']['socket_address']['port_value'])
+            except KeyError:
+                # If there is no socket_address and port_value, skip this listener
+                pass
+    return envoy_listeners
+
+
+def _get_envoy_service_info(
+    service_name: str,
+    service_info: ServiceInfo,
+    envoy_ingress_listeners: Mapping[int, int],
+) -> Optional[ServiceInfo]:
+    envoy_service_info: Optional[ServiceInfo] = None
+    local_host_port = service_info['port']
+    # If this service's local host port is being routed to from an Envoy ingress port,
+    # then output nerve configs so that this service will be healthchecked through
+    # the Envoy ingress port. This requires setting the healthcheck Host header too
+    # because Envoy uses the Host header for request routing.
+    #
+    # WARNING: Configuring nerve to have services healthchecked through Envoy may
+    # result in race conditions. The Envoy control plane will set up ingress ports
+    # based on a snapshot of currently running services on the local host, but the
+    # snapshot may change after the Envoy control plane does its work and before
+    # configure_nerve.py is run. This may result in a difference between what is
+    # actually running locally and the ingress ports that were set up. The worst
+    # case scenario is that nerve will start healthchecking services that aren't
+    # set up for routing in Envoy. In this case, healthchecks will fail, the service
+    # will not be registered in ZooKeeper, and the system will eventually be consistent.
+    if local_host_port in envoy_ingress_listeners:
+        service_info_copy = copy.deepcopy(service_info)
+        envoy_ingress_port = envoy_ingress_listeners[local_host_port]
+        healthcheck_headers: Dict[str, str] = {}
+        healthcheck_headers.update(service_info_copy.get('extra_healthcheck_headers', {}))
+        healthcheck_headers['Host'] = service_name
+        service_info_copy.update({
+            'host': get_ip_address(),
+            'port': envoy_ingress_port,
+            'healthcheck_port': envoy_ingress_port,
+            'extra_healthcheck_headers': healthcheck_headers,
+        })
+        envoy_service_info = cast(Optional[ServiceInfo], service_info_copy)
+    return envoy_service_info
+
+
+def generate_envoy_subsubconfiguration(
+    envoy_service_info: ServiceInfo,
+    healthcheck_mode: str,
+    service_name: str,
+    hacheck_port: int,
+    ip_address: str,
+    zookeeper_topology: Iterable[str],
+    labels: Dict[str, str],
+    weight: int,
+    deploy_group: Optional[str],
+    paasta_instance: Optional[str],
+) -> SubSubConfiguration:
+
+    # The service is full mesh enabled if we've gotten this far.
+    # Generate proper configs for:
+    # 1. Mesos: envoy_ingress_port -> local mesos docker port -> service
+    # 2. Kubernetes: envoy_ingress_port -> pod ip:port -> service
+
+    # hacheck healthchecks through envoy
+    healthcheck_port = envoy_service_info['port']
+    healthcheck_uri = envoy_service_info.get('healthcheck_uri', '/status')
+    # healthchecks via envoy for `http` services should be made via `https`.
+    healthcheck_mode = 'https' if healthcheck_mode == 'http' else healthcheck_mode
+    envoy_hacheck_uri = \
+        f"/{healthcheck_mode}/{service_name}/{healthcheck_port}/{healthcheck_uri.lstrip('/')}"
+    healthcheck_timeout_s = envoy_service_info.get('healthcheck_timeout_s', 1.0)
+    checks_dict: CheckDict = {
+        'type': 'http',
+        'host': get_ip_address(),
+        'port': hacheck_port,
+        'uri': envoy_hacheck_uri,
+        'timeout': healthcheck_timeout_s,
+        'open_timeout': healthcheck_timeout_s,
+        'rise': 1,
+        'fall': 2,
+        'headers': envoy_service_info['extra_healthcheck_headers'],
+    }
+
+    return SubSubConfiguration(
+        port=envoy_service_info['port'],
+        host=envoy_service_info.get('service_ip', ip_address),
+        zk_hosts=zookeeper_topology,
+        zk_path=f'/envoy/global/{service_name}',
+        check_interval=healthcheck_timeout_s + 1.0,
+        checks=[
+            checks_dict,
+        ],
+        labels=labels,
+        weight=weight,
+    )

--- a/src/nerve_tools/util.py
+++ b/src/nerve_tools/util.py
@@ -1,0 +1,8 @@
+import socket
+
+
+def get_hostname() -> str:
+    return socket.gethostname()
+
+def get_ip_address() -> str:
+    return socket.gethostbyname(get_hostname())

--- a/src/nerve_tools/util.py
+++ b/src/nerve_tools/util.py
@@ -4,5 +4,6 @@ import socket
 def get_hostname() -> str:
     return socket.gethostname()
 
-def get_ip_address() -> str:
+
+def get_host_ip() -> str:
     return socket.gethostbyname(get_hostname())

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,0 +1,4 @@
+coverage==4.5.4
+flake8==3.7.9
+mock==3.0.5
+pytest==5.2.1

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -1,10 +1,19 @@
 import copy
 import mock
+from mock import call
+from mock import patch
+from mock import mock_open
+from mock import MagicMock
+from mock import Mock
 import pytest
 import sys
 import multiprocessing
-from nerve_tools import configure_nerve
 from contextlib import contextmanager
+
+from typing import List
+
+from nerve_tools import configure_nerve
+from nerve_tools.configure_nerve import generate_subconfiguration
 
 
 try:
@@ -14,11 +23,11 @@ except NotImplementedError:
 
 
 def test_get_named_zookeeper_topology():
-    m = mock.mock_open()
-    with mock.patch(
+    m = mock_open()
+    with patch(
         'nerve_tools.configure_nerve.open',
         m, create=True
-    ), mock.patch(
+    ), patch(
         'yaml.load', return_value=[['foo', 42]]
     ):
         zk_topology = configure_nerve.get_named_zookeeper_topology(
@@ -37,7 +46,7 @@ def get_labels_by_service_and_port(service, port, labels_dir):
         return {}
 
 
-def get_current_location(typ):
+def get_current_location(typ: str) -> str:
     return {
         'ecosystem': 'my_ecosystem',
         'superregion': 'my_superregion',
@@ -46,7 +55,7 @@ def get_current_location(typ):
     }[typ]
 
 
-def convert_location_type(src_loc, src_typ, dst_typ):
+def convert_location_type(src_loc: str, src_typ: str, dst_typ: str) -> List[str]:
     if src_typ == dst_typ:
         return [src_loc]
     return {
@@ -126,15 +135,15 @@ def expected_sub_config():
 
 
 @pytest.fixture
-def expected_sub_config_with_envoy_listeners(expected_sub_config):
+def expected_sub_config_with_envoy_ingress_listeners(expected_sub_config):
     expected_sub_config.update({
-        'test_service.my_superregion:ip_address.1234': {
+        'test_service.my_superregion:service_ip.1234': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],
             'zk_path': '/envoy/global/test_service',
             'checks': [{
                 'rise': 1,
                 'uri': '/https/test_service/35000/status',
-                'host': '127.0.0.1',
+                'host': 'host_ip',
                 'timeout': 2.0,
                 'open_timeout': 2.0,
                 'fall': 2,
@@ -142,7 +151,7 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
                 'port': 6666,
                 'headers': {'Host': 'test_service'},
             }],
-            'host': 'ip_address',
+            'host': 'host_ip',
             'check_interval': 3.0,
             'port': 35000,
             'weight': mock.sentinel.weight,
@@ -155,13 +164,13 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
                 'paasta_instance': 'canary',
             },
         },
-        'test_service.another_superregion:ip_address.1234': {
+        'test_service.another_superregion:service_ip.1234': {
             'zk_hosts': ['3.4.5.6', '4.5.6.7'],
             'zk_path': '/envoy/global/test_service',
             'checks': [{
                 'rise': 1,
                 'uri': '/https/test_service/35000/status',
-                'host': '127.0.0.1',
+                'host': 'host_ip',
                 'timeout': 2.0,
                 'open_timeout': 2.0,
                 'fall': 2,
@@ -169,7 +178,7 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
                 'port': 6666,
                 'headers': {'Host': 'test_service'},
             }],
-            'host': 'ip_address',
+            'host': 'host_ip',
             'check_interval': 3.0,
             'port': 35000,
             'weight': mock.sentinel.weight,
@@ -185,50 +194,17 @@ def expected_sub_config_with_envoy_listeners(expected_sub_config):
     return expected_sub_config
 
 
-def test_get_envoy_listeners():
-    expected_envoy_listeners = {
-        1234: 54321,
-    }
-    mock_envoy_admin_listeners_return_value = {
-        'listener_statuses': [
-            {
-                'name': 'test_service.main.1234.ingress_listener',
-                'local_address': {
-                    'socket_address': {
-                        'address': '0.0.0.0',
-                        'port_value': 54321,
-                    },
-                },
-            },
-        ],
-    }
-    with mock.patch(
-        'nerve_tools.configure_nerve._get_envoy_listeners_from_admin',
-        return_value=mock_envoy_admin_listeners_return_value,
-    ):
-        assert configure_nerve.get_envoy_listeners(123) == \
-            expected_envoy_listeners
-
-
-def test_unsuccessful_get_envoy_listeners():
-    with mock.patch(
-        'nerve_tools.configure_nerve.requests.get',
-        side_effect=Exception,
-    ):
-        assert configure_nerve.get_envoy_listeners(123) == {}
-
-
 def test_generate_subconfiguration(expected_sub_config):
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_current_location',
         side_effect=get_current_location
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.convert_location_type',
         side_effect=convert_location_type
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_named_zookeeper_topology',
         side_effect=get_named_zookeeper_topology
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_labels_by_service_and_port',
         side_effect=get_labels_by_service_and_port
     ):
@@ -265,16 +241,16 @@ def test_generate_subconfiguration(expected_sub_config):
 
 
 def test_generate_subconfiguration_k8s(expected_sub_config):
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_current_location',
         side_effect=get_current_location
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.convert_location_type',
         side_effect=convert_location_type
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_named_zookeeper_topology',
         side_effect=get_named_zookeeper_topology
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_labels_by_service_and_port',
         side_effect=get_labels_by_service_and_port
     ):
@@ -320,21 +296,28 @@ def test_generate_subconfiguration_k8s(expected_sub_config):
     assert new_expected_sub_config == actual_config
 
 
-def test_generate_subconfiguration_with_envoy_listeners(expected_sub_config_with_envoy_listeners):
-    with mock.patch(
+def test_generate_subconfiguration_with_envoy_ingress_listeners(
+    expected_sub_config_with_envoy_ingress_listeners
+):
+    with patch(
         'nerve_tools.configure_nerve.get_current_location',
         side_effect=get_current_location
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.convert_location_type',
         side_effect=convert_location_type
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_named_zookeeper_topology',
         side_effect=get_named_zookeeper_topology
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_labels_by_service_and_port',
         side_effect=get_labels_by_service_and_port
+    ), patch(
+        'nerve_tools.configure_nerve.get_ip_address',
+        return_value='host_ip',
+    ), patch(
+        'nerve_tools.configure_nerve.get_ip_address',
+        return_value='host_ip',
     ):
-
         mock_service_info = {
             'port': 1234,
             'routes': [('remote_location', 'local_location')],
@@ -356,7 +339,7 @@ def test_generate_subconfiguration_with_envoy_listeners(expected_sub_config_with
             'extra_healthcheck_headers': {'Host': 'test_service'},
         })
 
-        actual_config = configure_nerve.generate_subconfiguration(
+        actual_config = generate_subconfiguration(
             service_name='test_service',
             service_info=mock_service_info,
             ip_address='ip_address',
@@ -369,7 +352,60 @@ def test_generate_subconfiguration_with_envoy_listeners(expected_sub_config_with
             envoy_service_info=mock_envoy_service_info,
         )
 
-    assert expected_sub_config_with_envoy_listeners == actual_config
+    assert expected_sub_config_with_envoy_ingress_listeners == actual_config
+
+
+# XXXXXXXXXXXXXXXXXXXXX
+# def test_generate_subconfiguration_with_full_mesh_envoy_listeners(expected_sub_config_with_envoy_listeners):
+#     with patch(
+#         'nerve_tools.configure_nerve.get_current_location',
+#         side_effect=get_current_location
+#     ), patch(
+#         'nerve_tools.configure_nerve.convert_location_type',
+#         side_effect=convert_location_type
+#     ), patch(
+#         'nerve_tools.configure_nerve.get_named_zookeeper_topology',
+#         side_effect=get_named_zookeeper_topology
+#     ), patch(
+#         'nerve_tools.configure_nerve.get_labels_by_service_and_port',
+#         side_effect=get_labels_by_service_and_port
+#     ):
+
+#         mock_service_info = {
+#             'port': 1234,
+#             'routes': [('remote_location', 'local_location')],
+#             'healthcheck_timeout_s': 2.0,
+#             'healthcheck_mode': 'http',
+#             'healthcheck_port': 1234,
+#             'advertise': ['region', 'superregion'],
+#             'extra_advertise': [
+#                 ('habitat:my_habitat', 'region:another_region'),
+#                 ('habitat:your_habitat', 'region:another_region'),  # Ignored
+#             ],
+#             'deploy_group': 'prod.canary',
+#             'paasta_instance': 'canary',
+#         }
+#         mock_envoy_service_info = copy.deepcopy(mock_service_info)
+#         mock_envoy_service_info.update({
+#             'port': 35000,
+#             'healthcheck_port': 35000,
+#             'extra_healthcheck_headers': {'Host': 'test_service'},
+#         })
+
+#         actual_config = configure_nerve.generate_subconfiguration(
+#             service_name='test_service',
+#             service_info=mock_service_info,
+#             ip_address='ip_address',
+#             hacheck_port=6666,
+#             weight=mock.sentinel.weight,
+#             zk_topology_dir='/fake/path',
+#             zk_location_type='superregion',
+#             zk_cluster_type='infrastructure',
+#             labels_dir='/dev/null',
+#             envoy_service_info=mock_envoy_service_info,
+#         )
+
+#     assert expected_sub_config_with_envoy_listeners == actual_config
 
 
 def test_generate_configuration_paasta_service():
@@ -381,13 +417,13 @@ def test_generate_configuration_paasta_service():
         'heartbeat_path': 'test'
     }
 
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_ip_address',
         return_value='ip_address'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_hostname',
         return_value='my_host'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.generate_subconfiguration',
         return_value={'foo': 17}
     ) as mock_generate_subconfiguration:
@@ -412,7 +448,7 @@ def test_generate_configuration_paasta_service():
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
             labels_dir='/dev/null',
-            envoy_listeners={},
+            envoy_ingress_listeners={},
         )
 
         mock_generate_subconfiguration.assert_called_once_with(
@@ -440,13 +476,13 @@ def test_generate_configuration_paasta_service_with_envoy_listeners():
         'heartbeat_path': 'test'
     }
 
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_ip_address',
         return_value='ip_address'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_hostname',
         return_value='my_host'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.generate_subconfiguration',
         return_value={'foo': 17}
     ) as mock_generate_subconfiguration:
@@ -458,7 +494,7 @@ def test_generate_configuration_paasta_service_with_envoy_listeners():
             'extra_advertise': [('habitat:my_habitat', 'region:another_region')],
         }
 
-        envoy_listeners = {1234: 35001}
+        envoy_ingress_listeners = {1234: 35001}
         mock_envoy_service_main_info = copy.deepcopy(mock_service_info)
         mock_envoy_service_main_info.update({
             'port': 35001,
@@ -491,11 +527,11 @@ def test_generate_configuration_paasta_service_with_envoy_listeners():
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
             labels_dir='/dev/null',
-            envoy_listeners=envoy_listeners,
+            envoy_ingress_listeners=envoy_ingress_listeners,
         )
 
         mock_generate_subconfiguration.assert_has_calls([
-            mock.call(
+            call(
                 service_name='test_service.main',
                 service_info=mock_service_info,
                 ip_address='ip_address',
@@ -507,7 +543,7 @@ def test_generate_configuration_paasta_service_with_envoy_listeners():
                 labels_dir='/dev/null',
                 envoy_service_info=mock_envoy_service_main_info,
             ),
-            mock.call(
+            call(
                 service_name='test_service.alt',
                 service_info=mock_service_info,
                 ip_address='ip_address',
@@ -533,13 +569,13 @@ def test_generate_configuration_healthcheck_port():
         'heartbeat_path': 'test'
     }
 
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_ip_address',
         return_value='ip_address'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_hostname',
         return_value='my_host'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.generate_subconfiguration',
         return_value={'foo': 17}
     ) as mock_generate_subconfiguration:
@@ -566,7 +602,7 @@ def test_generate_configuration_healthcheck_port():
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
             labels_dir='/dev/null',
-            envoy_listeners={},
+            envoy_ingress_listeners={},
         )
 
         mock_generate_subconfiguration.assert_called_once_with(
@@ -594,13 +630,13 @@ def test_generate_configuration_healthcheck_mode():
         'heartbeat_path': 'test'
     }
 
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_ip_address',
         return_value='ip_address'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_hostname',
         return_value='my_host'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.generate_subconfiguration',
         return_value={'foo': 17}
     ) as mock_generate_subconfiguration:
@@ -628,7 +664,7 @@ def test_generate_configuration_healthcheck_mode():
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
             labels_dir='/dev/null',
-            envoy_listeners={},
+            envoy_ingress_listeners={},
         )
 
         mock_generate_subconfiguration.assert_called_once_with(
@@ -648,10 +684,10 @@ def test_generate_configuration_healthcheck_mode():
 
 
 def test_generate_configuration_empty():
-    with mock.patch(
+    with patch(
         'nerve_tools.configure_nerve.get_ip_address',
         return_value='ip_address'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_hostname',
         return_value='my_host'
     ):
@@ -666,46 +702,46 @@ def test_generate_configuration_empty():
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
             labels_dir='/dev/null',
-            envoy_listeners={},
+            envoy_ingress_listeners={},
         )
         assert configuration == {'instance_id': 'my_host', 'services': {}, 'heartbeat_path': ''}
 
 
 @contextmanager
 def setup_mocks_for_main():
-    mock_sys = mock.MagicMock()
-    mock_file_cmp = mock.Mock()
-    mock_move = mock.Mock()
-    mock_subprocess_call = mock.Mock()
-    mock_subprocess_check_call = mock.Mock()
-    mock_sleep = mock.Mock()
-    mock_file_not_modified = mock.Mock(return_value=False)
+    mock_sys = MagicMock()
+    mock_file_cmp = Mock()
+    mock_move = Mock()
+    mock_subprocess_call = Mock()
+    mock_subprocess_check_call = Mock()
+    mock_sleep = Mock()
+    mock_file_not_modified = Mock(return_value=False)
 
-    with mock.patch.object(
+    with patch.object(
         sys, 'argv', ['configure-nerve']
-    ) as mock_sys, mock.patch(
+    ) as mock_sys, patch(
         'nerve_tools.configure_nerve.get_marathon_services_running_here_for_nerve'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.get_paasta_native_services_running_here_for_nerve'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.generate_configuration'
-    ), mock.patch(
+    ), patch(
         'nerve_tools.configure_nerve.open', create=True
-    ), mock.patch(
+    ), patch(
         'json.dump'
-    ), mock.patch(
+    ), patch(
         'os.chmod'
-    ), mock.patch(
+    ), patch(
         'filecmp.cmp'
-    ) as mock_file_cmp, mock.patch(
+    ) as mock_file_cmp, patch(
         'shutil.move'
-    ) as mock_move, mock.patch(
+    ) as mock_move, patch(
         'subprocess.call'
-    ) as mock_subprocess_call, mock.patch(
+    ) as mock_subprocess_call, patch(
         'subprocess.check_call'
-    ) as mock_subprocess_check_call, mock.patch(
+    ) as mock_subprocess_check_call, patch(
         'time.sleep'
-    ) as mock_sleep, mock.patch(
+    ) as mock_sleep, patch(
         'nerve_tools.configure_nerve.file_not_modified_since', return_value=False
     ) as mock_file_not_modified:
         mocks = (
@@ -718,11 +754,11 @@ def setup_mocks_for_main():
 def test_file_not_modified_since():
     fake_threshold = 10
     fake_path = '/somepath'
-    with mock.patch(
+    with patch(
         'time.time'
-    ) as mock_time, mock.patch(
+    ) as mock_time, patch(
         'os.path.isfile', return_value=True
-    ), mock.patch(
+    ), patch(
         'os.path.getmtime',
     ) as mock_getmtime:
 
@@ -740,17 +776,17 @@ def test_nerve_restarted_when_config_files_differ():
         mock_file_cmp.return_value = False
         configure_nerve.main()
 
-        expected_move = mock.call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
+        expected_move = call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
         assert mock_move.call_args_list == [expected_move]
 
         expected_subprocess_calls = (
-            mock.call(['service', 'nerve-backup', 'start']),
-            mock.call(['service', 'nerve-backup', 'stop']),
+            call(['service', 'nerve-backup', 'start']),
+            call(['service', 'nerve-backup', 'stop']),
         )
         expected_subprocess_check_calls = (
-            mock.call(['service', 'nerve', 'start']),
-            mock.call(['service', 'nerve', 'stop']),
-            mock.call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
+            call(['service', 'nerve', 'start']),
+            call(['service', 'nerve', 'stop']),
+            call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
         )
 
         actual_subprocess_calls = mock_subprocess_call.call_args_list
@@ -777,11 +813,11 @@ def test_nerve_not_restarted_when_configs_files_are_identical():
         mock_file_cmp.return_value = True
         configure_nerve.main()
 
-        expected_move = mock.call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
+        expected_move = call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
         assert mock_move.call_args_list == [expected_move]
 
         expected_subprocess_check_calls = [
-            mock.call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
+            call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
         ]
 
         actual_subprocess_calls = mock_subprocess_call.call_args_list
@@ -802,17 +838,17 @@ def test_nerve_restarted_when_heartbeat_file_stale():
         mock_file_not_modified.return_value = True
         configure_nerve.main()
 
-        expected_move = mock.call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
+        expected_move = call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
         assert mock_move.call_args_list == [expected_move]
 
         expected_subprocess_calls = (
-            mock.call(['service', 'nerve-backup', 'start']),
-            mock.call(['service', 'nerve-backup', 'stop']),
+            call(['service', 'nerve-backup', 'start']),
+            call(['service', 'nerve-backup', 'stop']),
         )
         expected_subprocess_check_calls = (
-            mock.call(['service', 'nerve', 'start']),
-            mock.call(['service', 'nerve', 'stop']),
-            mock.call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
+            call(['service', 'nerve', 'start']),
+            call(['service', 'nerve', 'stop']),
+            call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
         )
 
         actual_subprocess_calls = mock_subprocess_call.call_args_list
@@ -839,11 +875,11 @@ def test_nerve_not_restarted_when_heartbeat_file_valid():
         mock_file_cmp.return_value = True
         configure_nerve.main()
 
-        expected_move = mock.call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
+        expected_move = call('/etc/nerve/nerve.conf.json.tmp', '/etc/nerve/nerve.conf.json')
         assert mock_move.call_args_list == [expected_move]
 
         expected_subprocess_check_calls = [
-            mock.call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
+            call(['/usr/bin/nerve', '-c', '/etc/nerve/nerve.conf.json.tmp', '-k'])
         ]
 
         actual_subprocess_calls = mock_subprocess_call.call_args_list

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -146,7 +146,7 @@ def expected_sub_config_with_envoy_ingress_listeners(expected_sub_config):
     for k, v in expected_sub_config.items():
         new_expected_sub_config[k.replace('10.0.0.1', '10.4.5.6')] = expected_sub_config[k]
 
-    # Add in full mesh envoy configs sor same service
+    # Add in full mesh envoy configs for the same service
     new_expected_sub_config.update({
         'test_service.my_superregion:10.4.5.6.1234': {
             'zk_hosts': ['1.2.3.4', '2.3.4.5'],

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -456,7 +456,11 @@ def test_generate_configuration_paasta_service_with_envoy_ingress_listeners():
             'extra_advertise': [('habitat:my_habitat', 'region:another_region')],
         }
 
-        envoy_ingress_listeners = {1234: 35001}
+        envoy_ingress_listeners = {
+            ('test_service.main', 1234): 35001,
+            ('test_service.alt', 1234): 35001,
+        }
+
         mock_envoy_service_main_info = copy.deepcopy(mock_service_info)
         mock_envoy_service_main_info.update({
             'host': 'ip_address',

--- a/src/tests/envoy_test.py
+++ b/src/tests/envoy_test.py
@@ -1,0 +1,40 @@
+from mock import patch
+
+from nerve_tools.envoy import get_envoy_ingress_listeners
+
+
+def test_get_envoy_ingress_listeners_success():
+    expected_envoy_listeners = {
+        1234: 54321,
+    }
+    mock_envoy_admin_listeners_return_value = {
+        'listener_statuses': [
+            {
+                'name': 'test_service.main.1234.ingress_listener',
+                'local_address': {
+                    'socket_address': {
+                        'address': '0.0.0.0',
+                        'port_value': 54321,
+                    },
+                },
+            },
+        ],
+    }
+    with patch(
+        'nerve_tools.envoy._get_envoy_listeners_from_admin',
+        return_value=mock_envoy_admin_listeners_return_value,
+    ):
+        assert get_envoy_ingress_listeners(123) == expected_envoy_listeners
+
+
+def test_get_envoy_ingress_listeners_failure():
+    with patch(
+        'nerve_tools.envoy.requests.get',
+        side_effect=Exception,
+    ):
+        assert get_envoy_ingress_listeners(123) == {}
+
+
+def test_generate_envoy_subsubconfiguration():
+    # TODO(spatel)
+    pass

--- a/src/tests/envoy_test.py
+++ b/src/tests/envoy_test.py
@@ -33,8 +33,3 @@ def test_get_envoy_ingress_listeners_failure():
         side_effect=Exception,
     ):
         assert get_envoy_ingress_listeners(123) == {}
-
-
-def test_generate_envoy_subsubconfiguration():
-    # TODO(spatel)
-    pass

--- a/src/tests/envoy_test.py
+++ b/src/tests/envoy_test.py
@@ -5,7 +5,7 @@ from nerve_tools.envoy import get_envoy_ingress_listeners
 
 def test_get_envoy_ingress_listeners_success():
     expected_envoy_listeners = {
-        1234: 54321,
+        ('test_service.main', 1234): 54321,
     }
     mock_envoy_admin_listeners_return_value = {
         'listener_statuses': [

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -4,11 +4,10 @@
 basepython=python3.6
 deps =
     -r{toxinidir}/requirements.txt
-    flake8
-    pytest
-    mock==1.0.1
+    -r{toxinidir}/requirements-dev.txt
 commands =
-    py.test {posargs:tests}
+    coverage run -m py.test {posargs:tests}
+    coverage report -m --include nerve_tools/* --show-missing --skip-covered --fail-under 75
     flake8 nerve_tools tests
 
 [testenv:trusty]


### PR DESCRIPTION
Main features:
- Supports envoy ingress listeners for kubernetes backed services and adds them to nerve.conf.json accordingly.

Fixed while I was in there:
- broke out envoy stuff into envoy.py
- broke out config data classes into config.py
- replaced ip_address with host_ip or service_ip to disambiguate what the ip addr actually represents (only in new/updated code)

Testing:
- added test coverage with fails under 75%
- verified test coverage execution for newly added code