### PR TITLE
Support k8s pod ip in envoy listener name

### DIFF
--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y install \
     dh-virtualenv \
     dpkg-dev \
     gdebi-core \
+    host \
     libcurl4-openssl-dev \
     libffi-dev \
     libssl-dev \

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y install \
     dh-virtualenv \
     dpkg-dev \
     gdebi-core \
+    host \
     libcurl4-openssl-dev \
     libffi-dev \
     libssl-dev \

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get -y install \
     # Install for deps even though we install newer version below
     dh-virtualenv \
     dpkg-dev \
+    host \
     libcurl4-openssl-dev \
     libffi-dev \
     libssl-dev \

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -19,9 +19,10 @@ override_dh_auto_build:
 override_dh_auto_test:
 	true
 
-# this has a tendency to fail, hence the --verbose to dump a useful stacktrace
+# Add --verbose right after dh_virtualenv if the build fails and doesn't leave a useful stacktrace. Unfortunately, 
+# TravisCI can't handle the large logs that verbose output creates and it will just terminate the build :(
 override_dh_virtualenv:
-	dh_virtualenv --verbose `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
 	--python=/usr/bin/python3.6 \
 	--preinstall no-manylinux1 \
 	--preinstall=-rrequirements-bootstrap.txt \

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -19,9 +19,10 @@ override_dh_auto_build:
 override_dh_auto_test:
 	true
 
+# this has a tendency to fail, hence the --verbose to dump a useful stacktrace
 override_dh_virtualenv:
-	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
-    --python=/usr/bin/python3.6 \
+	dh_virtualenv --verbose `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	--python=/usr/bin/python3.6 \
 	--preinstall no-manylinux1 \
-    --preinstall=-rrequirements-bootstrap.txt \
+	--preinstall=-rrequirements-bootstrap.txt \
 	--pip-tool pip-custom-platform

--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -245,7 +245,7 @@ def generate_configuration(
     zk_location_type: str,
     zk_cluster_type: str,
     labels_dir: str,
-    envoy_ingress_listeners: Mapping[Tuple[str, int], int],
+    envoy_ingress_listeners: Mapping[Tuple[str, str, int], int],
 ) -> NerveConfig:
     nerve_config: NerveConfig = {
         'instance_id': get_hostname(),

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -74,7 +74,7 @@ def get_envoy_service_info(
     # mesos port -> envoy ingress port mapping was pretty straight forward. With
     # Kubernetes services, the port is not guaranteed to be unique to this host
     # because of the pod abstraction which introduces a pod ip address. Thus, to
-    # maintain a valid mapping, a composite key (service_name, servie_ip, service_port) is used
+    # maintain a valid mapping, a composite key (service_name, service_ip, service_port) is used
     # to map to the service's envoy ingress port.
     key = (service_name, service_info.get('service_ip', MESOS_SERVICE_IP), service_info['port'])
 

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -17,7 +17,9 @@ from nerve_tools.config import SubSubConfiguration
 from nerve_tools.util import get_host_ip
 
 
-INGRESS_LISTENER_REGEX = re.compile(r'^(?P<service_name>\S+\.\S+)\.(?P<service_port>\d+)\.ingress_listener$')
+INGRESS_LISTENER_REGEX = re.compile(
+    r'^(?P<service_name>\S+\.\S+)\.(?P<service_ip>\d+\.\d+\.\d+\.\d+)\.(?P<service_port>\d+)\.ingress_listener$'
+)
 
 
 def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[ListenerConfig]]:
@@ -28,22 +30,30 @@ def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[Li
         return {}
 
 
-def get_envoy_ingress_listeners(admin_port: int) -> Mapping[Tuple[str, int], int]:
-    """Compile a mapping of "service's local listening port" -> "the corresponding Envoy
-    ingress port".
+def get_envoy_ingress_listeners(admin_port: int) -> Mapping[Tuple[str, str, int], int]:
+    """Compile a mapping of (service, ip, port) -> envoy ingress port for service
 
     This will be used to determine the Envoy ingress port for a given service's actual port.
     """
-    envoy_listeners: Dict[Tuple[str, int], int] = {}
+    envoy_listeners: Dict[
+        Tuple[
+            str,  # service name
+            str,  # service ip
+            int   # service port
+        ],
+        int,      # ingress envoy port for service
+    ] = {}
+
     envoy_listeners_config = _get_envoy_listeners_from_admin(admin_port)
 
     for listener in envoy_listeners_config.get('listener_statuses', []):
         result = INGRESS_LISTENER_REGEX.match(listener['name'])
         if result:
             service_name = result.group('service_name')
-            service_port = result.group('service_port')
+            service_ip = result.group('service_ip')
+            service_port = int(result.group('service_port'))
             try:
-                envoy_listeners[(service_name, int(service_port))] = \
+                envoy_listeners[(service_name, service_ip, service_port)] = \
                     int(listener['local_address']['socket_address']['port_value'])
             except KeyError:
                 # If there is no socket_address and port_value, skip this listener
@@ -54,7 +64,7 @@ def get_envoy_ingress_listeners(admin_port: int) -> Mapping[Tuple[str, int], int
 def get_envoy_service_info(
     service_name: str,
     service_info: ServiceInfo,
-    envoy_ingress_listeners: Mapping[Tuple[str, int], int],
+    envoy_ingress_listeners: Mapping[Tuple[str, str, int], int],
 ) -> Optional[ServiceInfo]:
     envoy_service_info: Optional[ServiceInfo] = None
 
@@ -62,17 +72,9 @@ def get_envoy_service_info(
     # mesos port -> envoy ingress port mapping was pretty straight forward. With
     # Kubernetes services, the port is not guaranteed to be unique to this host
     # because of the pod abstraction which introduces a pod ip address. Thus, to
-    # maintain a valid mapping, a composite key (service_name, service_port) is used
+    # maintain a valid mapping, a composite key (service_name, servie_ip, service_port) is used
     # to map to the service's envoy ingress port.
-    #
-    # This is not fullproof! multiple instances of the same service may be scheudled
-    # to run on this host. The (service_name, service_ip, service_port) is the only
-    # key that would maintain uniqueness, but service_ip (the pod_id in the case of k8s)
-    # is not part of the information returned from the envoy admin port /listener
-    # response.
-
-    # TODO(spatel) Figure out a tighter solution here
-    key = (service_name, service_info['port'])
+    key = (service_name, service_info['service_ip'], service_info['port'])
 
     # If this service's local host port is being routed to from an Envoy ingress port,
     # then output nerve configs so that this service will be healthchecked through

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -21,6 +21,8 @@ INGRESS_LISTENER_REGEX = re.compile(
     r'^(?P<service_name>\S+\.\S+)\.(?P<service_ip>\d+\.\d+\.\d+\.\d+)\.(?P<service_port>\d+)\.ingress_listener$'
 )
 
+MESOS_SERVICE_IP = '0.0.0.0'
+
 
 def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[ListenerConfig]]:
     try:
@@ -74,7 +76,7 @@ def get_envoy_service_info(
     # because of the pod abstraction which introduces a pod ip address. Thus, to
     # maintain a valid mapping, a composite key (service_name, servie_ip, service_port) is used
     # to map to the service's envoy ingress port.
-    key = (service_name, service_info['service_ip'], service_info['port'])
+    key = (service_name, service_info.get('service_ip', MESOS_SERVICE_IP), service_info['port'])
 
     # If this service's local host port is being routed to from an Envoy ingress port,
     # then output nerve configs so that this service will be healthchecked through

--- a/src/requirements-bootstrap.txt
+++ b/src/requirements-bootstrap.txt
@@ -1,3 +1,4 @@
 pip==9.0.3
 pip-custom-platform==0.5.0
+setuptools==41.4.0
 wheel==0.30.0

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -388,6 +388,7 @@ def test_generate_configuration_paasta_service():
     ) as mock_generate_subconfiguration:
 
         mock_service_info = {
+            'service_ip': '0.0.0.0',
             'port': 1234,
             'healthcheck_timeout_s': 2.0,
             'advertise': ['region'],
@@ -450,6 +451,7 @@ def test_generate_configuration_paasta_service_with_envoy_ingress_listeners():
     ) as mock_generate_subconfiguration:
 
         mock_service_info = {
+            'service_ip': '10.45.13.8',
             'port': 1234,
             'healthcheck_timeout_s': 2.0,
             'advertise': ['region'],
@@ -457,8 +459,8 @@ def test_generate_configuration_paasta_service_with_envoy_ingress_listeners():
         }
 
         envoy_ingress_listeners = {
-            ('test_service.main', 1234): 35001,
-            ('test_service.alt', 1234): 35001,
+            ('test_service.main', '10.45.13.8', 1234): 35001,
+            ('test_service.alt', '10.45.13.8', 1234): 35001,
         }
 
         mock_envoy_service_main_info = copy.deepcopy(mock_service_info)
@@ -549,6 +551,7 @@ def test_generate_configuration_healthcheck_port():
     ) as mock_generate_subconfiguration:
 
         mock_service_info = {
+            'service_ip': '0.0.0.0',
             'port': 1234,
             'routes': [('remote_location', 'local_location')],
             'healthcheck_timeout_s': 2.0,
@@ -610,6 +613,7 @@ def test_generate_configuration_healthcheck_mode():
     ) as mock_generate_subconfiguration:
 
         mock_service_info = {
+            'service_ip': '0.0.0.0',
             'port': 1234,
             'routes': [('remote_location', 'local_location')],
             'healthcheck_timeout_s': 2.0,

--- a/src/tests/envoy_test.py
+++ b/src/tests/envoy_test.py
@@ -5,12 +5,12 @@ from nerve_tools.envoy import get_envoy_ingress_listeners
 
 def test_get_envoy_ingress_listeners_success():
     expected_envoy_listeners = {
-        ('test_service.main', 1234): 54321,
+        ('test_service.main', '10.45.13.4', 1234): 54321,
     }
     mock_envoy_admin_listeners_return_value = {
         'listener_statuses': [
             {
-                'name': 'test_service.main.1234.ingress_listener',
+                'name': 'test_service.main.10.45.13.4.1234.ingress_listener',
                 'local_address': {
                     'socket_address': {
                         'address': '0.0.0.0',


### PR DESCRIPTION
This nerve-toosl PR is meant to be shipped with the internal CR for meshd under CORESERV-9319.  

Both meshd and nerve-tools were tested on stagef to verify ingress traffic to multiple pods for the same service on a single host works without a hitch: https://fluffy.yelpcorp.com/i/94hFVtlfzjgw4GkWdC4tHGwNTqzzGKjJ.html