### PR TITLE
Fix version conflict breaking build

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,6 +5,6 @@ kazoo==2.2
 mypy-extensions==0.4.1
 paasta-tools==0.90.4
 PyYAML==4.2b1
-requests==2.20.0
+requests==2.23.0
 service-configuration-lib==0.12.0
 setuptools==40.3.0


### PR DESCRIPTION
cookiecutter==1.7.2 requires a requests>=2.23.0. This ended up breaking `configure_nerve` when run in our itests:

    pkg_resources.ContextualVersionConflict: (requests 2.20.0 (/opt/venvs/nerve-tools/lib/python3.6/site-packages), Requirement.parse('requests>=2.23.0'), {'cookiecutter'})

Updating requests to the min required version.