### PR TITLE
Disable envoy lookup when admin-envoy-port is not specified

### DIFF
--- a/src/nerve_tools/configure_nerve.py
+++ b/src/nerve_tools/configure_nerve.py
@@ -343,7 +343,7 @@ def parse_args(
                         help='weight to advertise each service at. Defaults to # of CPUs')
     parser.add_argument('--labels-dir', type=str, default=DEFAULT_LABEL_DIR,
                         help='Directory containing custom labels for nerve services.')
-    parser.add_argument('--envoy-admin-port', type=int, default=9901,
+    parser.add_argument('--envoy-admin-port', type=int,
                         help='Port for envoy admin to get configured envoy listeners.')
 
     return parser.parse_args(args)

--- a/src/nerve_tools/envoy.py
+++ b/src/nerve_tools/envoy.py
@@ -32,7 +32,7 @@ def _get_envoy_listeners_from_admin(admin_port: int) -> Mapping[str, Iterable[Li
         return {}
 
 
-def get_envoy_ingress_listeners(admin_port: int) -> Mapping[Tuple[str, str, int], int]:
+def get_envoy_ingress_listeners(admin_port: Optional[int]) -> Mapping[Tuple[str, str, int], int]:
     """Compile a mapping of (service, ip, port) -> envoy ingress port for service
 
     This will be used to determine the Envoy ingress port for a given service's actual port.
@@ -45,6 +45,9 @@ def get_envoy_ingress_listeners(admin_port: int) -> Mapping[Tuple[str, str, int]
         ],
         int,      # ingress envoy port for service
     ] = {}
+
+    if admin_port is None:
+        return {}
 
     envoy_listeners_config = _get_envoy_listeners_from_admin(admin_port)
 

--- a/src/tests/envoy_test.py
+++ b/src/tests/envoy_test.py
@@ -33,3 +33,10 @@ def test_get_envoy_ingress_listeners_failure():
         side_effect=Exception,
     ):
         assert get_envoy_ingress_listeners(123) == {}
+
+
+def test_get_envoy_ingress_listeners_no_query_when_envoy_disabled():
+    with patch('nerve_tools.envoy.requests.get') as mock_requests:
+        admin_port = None
+        get_envoy_ingress_listeners(admin_port)
+    mock_requests.assert_not_called()


### PR DESCRIPTION
When `--admin-envoy-port` is not defined, skip envoy listener discovery.