### PR TITLE
itests don't clutter gitroot

### DIFF
--- a/dockerfiles/bionic/docker-compose.yml
+++ b/dockerfiles/bionic/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 services:
   bionic:
     build: ../../dockerfiles/bionic
-    command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    command: bash -c "cp -R /code/* /work && cd /work/src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb /dist"
     volumes:
-     - ../..:/work
+      - ../..:/code:ro
+      - ../../dist:/dist

--- a/dockerfiles/trusty/docker-compose.yml
+++ b/dockerfiles/trusty/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 services:
   trusty:
     build: ../../dockerfiles/trusty
-    command: bash -c "cd src && tox -e trusty && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    command: bash -c "cp -R /code/* /work && cd /work/src && tox -e trusty && dpkg-buildpackage -d -uc -us && mv ../*.deb /dist"
     volumes:
-     - ../..:/work
+      - ../..:/code:ro
+      - ../../dist:/dist

--- a/dockerfiles/xenial/docker-compose.yml
+++ b/dockerfiles/xenial/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 services:
   xenial:
     build: ../../dockerfiles/xenial
-    command: bash -c "cd src && tox -e xenial && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    command: bash -c "cp -R /code/* /work && cd /work/src && tox -e xenial && dpkg-buildpackage -d -uc -us && mv ../*.deb /dist"
     volumes:
-     - ../..:/work
+      - ../..:/code:ro
+      - ../../dist:/dist


### PR DESCRIPTION
Dockerfiles directly mounted the gitroot rw, allowing the build to clutter the gitroot with root-owned build files.

This change isolates the build to the docker container.