### PR TITLE
Ensure internal yelp builds use internal pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ install: pip install tox
 python:
   - "3.6"
 env:
-  - MAKE_TARGET=itest_trusty
-  - MAKE_TARGET=itest_xenial
-  - MAKE_TARGET=itest_bionic
-  - MAKE_TARGET=mypy
+  global:
+    - PIP_INDEX_URL=https://pypi.python.org/simple
+  jobs:
+    - MAKE_TARGET=itest_trusty
+    - MAKE_TARGET=itest_xenial
+    - MAKE_TARGET=itest_bionic
+    - MAKE_TARGET=mypy
 script: make "$MAKE_TARGET"
 deploy:
   - provider: bintray

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
 DATE := $(shell date +'%Y-%m-%d')
 NERVETOOLSVERSION := $(shell sed 's/.*(\(.*\)).*/\1/;q' src/debian/changelog)
 bintray.json: bintray.json.in src/debian/changelog

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:bionic
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 RUN apt-get update && apt-get -y install \
     build-essential \
     debhelper \
+    curl \
     dh-virtualenv \
     dpkg-dev \
     gdebi-core \
@@ -13,12 +17,17 @@ RUN apt-get update && apt-get -y install \
     libyaml-dev \
     libzookeeper-mt-dev \
     protobuf-compiler \
-    python-pip \
     python-setuptools \
     python-tox \
     python3-setuptools \
     python3.6-dev \
     wget
+
+
+# Preferred method to install pip when not bundled with python - https://pip.pypa.io/en/stable/installing/
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+# last internal setuptools with python2 support
+RUN python2 get-pip.py setuptools==42.0.2
 
 # Latest version of internally hosted virtualenv that works with dh-virtualenv 1.0-1. Later
 # versions removed (well, 20.x, at least) --no-site-packages flag which dh-virtualenv needs.

--- a/dockerfiles/bionic/docker-compose.yml
+++ b/dockerfiles/bionic/docker-compose.yml
@@ -1,5 +1,7 @@
-bionic:
-  build: ../../dockerfiles/bionic
-  command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  bionic:
+    build: ../../dockerfiles/bionic
+    command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/dockerfiles/itest/docker-compose-bionic.yml
+++ b/dockerfiles/itest/docker-compose-bionic.yml
@@ -1,28 +1,30 @@
-itest:
-  build: ../../dockerfiles/itest/itest_bionic
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  links:
-   - servicethree
-   - serviceone
-   - scribe
-   - zookeeper
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_bionic
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    links:
+     - servicethree
+     - serviceone
+     - scribe
+     - zookeeper
 
-servicethree:
-  # Create dummy service listening on port 1024 that returns /status
-  image: python:3-alpine
-  command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
+  servicethree:
+    # Create dummy service listening on port 1024 that returns /status
+    image: python:3-alpine
+    command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
 
-serviceone:
-  # Create dummy service listening on port 1025
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1025,fork /dev/null
+  serviceone:
+    # Create dummy service listening on port 1025
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1025,fork /dev/null
 
-scribe:
-  # Create dummy scribe listening on port 1464
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1464,fork /dev/null
+  scribe:
+    # Create dummy scribe listening on port 1464
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1464,fork /dev/null
 
-zookeeper:
-  image: zookeeper:3.5
+  zookeeper:
+    image: zookeeper:3.5

--- a/dockerfiles/itest/docker-compose-trusty.yml
+++ b/dockerfiles/itest/docker-compose-trusty.yml
@@ -1,28 +1,30 @@
-itest:
-  build: ../../dockerfiles/itest/itest_trusty
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  links:
-   - servicethree
-   - serviceone
-   - scribe
-   - zookeeper
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_trusty
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    links:
+     - servicethree
+     - serviceone
+     - scribe
+     - zookeeper
 
-servicethree:
-  # Create dummy service listening on port 1024 that returns /status
-  image: python:3-alpine
-  command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
+  servicethree:
+    # Create dummy service listening on port 1024 that returns /status
+    image: python:3-alpine
+    command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
 
-serviceone:
-  # Create dummy service listening on port 1025
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1025,fork /dev/null
+  serviceone:
+    # Create dummy service listening on port 1025
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1025,fork /dev/null
 
-scribe:
-  # Create dummy scribe listening on port 1464
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1464,fork /dev/null
+  scribe:
+    # Create dummy scribe listening on port 1464
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1464,fork /dev/null
 
-zookeeper:
-  image: zookeeper:3.5
+  zookeeper:
+    image: zookeeper:3.5

--- a/dockerfiles/itest/docker-compose-xenial.yml
+++ b/dockerfiles/itest/docker-compose-xenial.yml
@@ -1,29 +1,31 @@
-itest:
-  build: ../../dockerfiles/itest/itest_xenial
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  links:
-   - servicethree
-   - serviceone
-   - scribe
-   - zookeeper
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_xenial
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    links:
+     - servicethree
+     - serviceone
+     - scribe
+     - zookeeper
 
-servicethree:
-  #build: ../../dockerfiles/itest/service_three
-  # Create dummy service listening on port 1024 that returns /status
-  image: python:3-alpine
-  command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
+  servicethree:
+    #build: ../../dockerfiles/itest/service_three
+    # Create dummy service listening on port 1024 that returns /status
+    image: python:3-alpine
+    command:  /bin/sh -c "echo OK > status && python3 -m http.server 1024"
 
-serviceone:
-  # Create dummy service listening on port 1025
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1025,fork /dev/null
+  serviceone:
+    # Create dummy service listening on port 1025
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1025,fork /dev/null
 
-scribe:
-  # Create dummy scribe listening on port 1464
-  image: alpine/socat:latest
-  command: TCP4-LISTEN:1464,fork /dev/null
+  scribe:
+    # Create dummy scribe listening on port 1464
+    image: alpine/socat:latest
+    command: TCP4-LISTEN:1464,fork /dev/null
 
-zookeeper:
-  image: zookeeper:3.5
+  zookeeper:
+    image: zookeeper:3.5

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -1,5 +1,7 @@
 FROM ubuntu:bionic
-MAINTAINER John Billings <billings@yelp.com>
+
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
 RUN apt-get update && apt-get -y install \
     python-setuptools \
@@ -16,7 +18,7 @@ RUN apt-get update && apt-get -y install \
     libyaml-dev
 
 RUN pip install pip==1.5.6
-RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && python setup.py install --install-scripts=/usr/bin
+RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && pip install . && cp /usr/local/bin/* /usr/bin/
 
 # Install nerve
 ADD nerve_Gemfile Gemfile

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -1,5 +1,7 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
+
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
 # Need Python 3.6
 RUN apt-get update && \
@@ -19,7 +21,7 @@ RUN apt-get update && apt-get -y install \
     git \
     libyaml-dev
 
-RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && python setup.py install --install-scripts=/usr/bin
+RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && pip install . && cp /usr/local/bin/* /usr/bin/
 
 # Install nerve
 ADD nerve_Gemfile Gemfile
@@ -29,7 +31,7 @@ RUN mkdir -p /opt/nerve
 RUN bundle install --gemfile=/Gemfile
 RUN bundle binstubs nerve --path /usr/bin
 
-RUN easy_install zope.interface
+RUN pip install zope.interface
 
 ADD nerve.conf /etc/init/nerve.conf
 ADD nerve.conf /etc/init/nerve-backup.conf

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -1,5 +1,7 @@
 FROM ubuntu:xenial
-MAINTAINER John Billings <billings@yelp.com>
+
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 
 # Need Python 3.6
 RUN apt-get update && \
@@ -20,7 +22,7 @@ RUN apt-get update && apt-get -y install \
     libyaml-dev
 
 RUN pip install pip==1.5.6
-RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && python setup.py install --install-scripts=/usr/bin
+RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && pip install . && cp /usr/local/bin/* /usr/bin/
 
 # Install nerve
 ADD nerve_Gemfile Gemfile

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:14.04
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6 for nerve-tools
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
@@ -36,7 +39,9 @@ RUN apt-get purge -y \
     python-six-whl
 
 # Preferred method to install pip when not bundled with python - https://pip.pypa.io/en/stable/installing/
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+# last internal setuptools with python2 support
+RUN python2 get-pip.py setuptools==42.0.2
 
 RUN pip install -U tox pip virtualenv==16.7.5
 

--- a/dockerfiles/trusty/docker-compose.yml
+++ b/dockerfiles/trusty/docker-compose.yml
@@ -1,5 +1,7 @@
-trusty:
-  build: ../../dockerfiles/trusty
-  command: bash -c "cd src && tox -e trusty && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  trusty:
+    build: ../../dockerfiles/trusty
+    command: bash -c "cd src && tox -e trusty && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:xenial
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6 for nerve-tools
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
@@ -29,7 +32,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1 
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 2
 
 # Preferred method to install pip when not bundled with python - https://pip.pypa.io/en/stable/installing/
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+# last internal setuptools with python2 support
+RUN python2 get-pip.py setuptools==42.0.2
 
 # Latest version of internally hosted virtualenv that works with dh-virtualenv 1.0-1. Later
 # versions removed (well, 20.x, at least) --no-site-packages flag which dh-virtualenv needs.

--- a/dockerfiles/xenial/docker-compose.yml
+++ b/dockerfiles/xenial/docker-compose.yml
@@ -1,5 +1,7 @@
-xenial:
-  build: ../../dockerfiles/xenial
-  command: bash -c "cd src && tox -e xenial && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  xenial:
+    build: ../../dockerfiles/xenial
+    command: bash -c "cd src && tox -e xenial && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
 export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 
 export DH_OPTIONS
@@ -22,7 +23,7 @@ override_dh_auto_test:
 # Add --verbose right after dh_virtualenv if the build fails and doesn't leave a useful stacktrace. Unfortunately, 
 # TravisCI can't handle the large logs that verbose output creates and it will just terminate the build :(
 override_dh_virtualenv:
-	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	dh_virtualenv -i $(PIP_INDEX_URL) \
 	--python=/usr/bin/python3.6 \
 	--preinstall no-manylinux1 \
 	--preinstall=-rrequirements-bootstrap.txt \

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ paasta-tools==0.90.4
 PyYAML==4.2b1
 requests==2.23.0
 service-configuration-lib==0.12.0
-setuptools==40.3.0
+setuptools==42.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
 skipsdist = true
-docker_compose_version = 1.23.2
+docker_compose_version = 1.26.2
 
 [testenv]
+# The Makefile and .travis.yml override the indexserver to the public one when
+# running outside of Yelp.
+indexserver = https://pypi.yelpcorp.com/simple
 deps =
     docker-compose=={[tox]docker_compose_version}
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
+setenv =
+    PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
 
 [testenv:package_trusty]
 whitelist_externals = /bin/cp
@@ -14,7 +19,7 @@ setenv =
 commands =
     cp dockerfiles/itest/itest/yelpsoa-configs/location_mapping.json dockerfiles/itest/itest/yelpsoa-configs/location_types.json dockerfiles/trusty/
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run trusty
     docker-compose stop
     docker-compose rm --force
@@ -26,7 +31,7 @@ setenv =
 commands =
     cp dockerfiles/itest/itest/yelpsoa-configs/location_mapping.json dockerfiles/itest/itest/yelpsoa-configs/location_types.json dockerfiles/xenial/
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run xenial
     docker-compose stop
     docker-compose rm --force
@@ -38,7 +43,7 @@ setenv =
 commands =
     cp dockerfiles/itest/itest/yelpsoa-configs/location_mapping.json dockerfiles/itest/itest/yelpsoa-configs/location_types.json dockerfiles/bionic/
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run bionic
     docker-compose stop
     docker-compose rm --force
@@ -48,7 +53,7 @@ setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-trusty.yml
 commands =
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force
@@ -58,7 +63,7 @@ setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-xenial.yml
 commands =
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force
@@ -68,7 +73,7 @@ setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-bionic.yml
 commands =
     docker-compose down
-    docker-compose --verbose build --no-cache
+    docker-compose --verbose build --no-cache --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force


### PR DESCRIPTION
Mostly for security reasons we don't want to build from public pypi
internally. We do want to use it for travis of course. Had to upgrade
docker compose to make it pass a build arg. I think I caught everything
pip does, largely copying approach by vkhromov in
https://github.com/Yelp/paasta/pull/2872