### PR TITLE
Fix internal build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+overrides = [
+  clone: [
+    gitServer: 'git@github.com',
+    repoBranch: 'origin/master',
+  ],
+  platforms: ['trusty', 'xenial', 'bionic']
+]
+buildDebianPackage(overrides)

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get -y install \
     python-dev \
     python-pip \
     git \
-    libyaml-dev
+    libyaml-dev \
+    libc6-dev \
+    libstdc++6
 
 RUN pip install pip==1.5.6
 RUN git clone --branch yelp https://github.com/Yelp/hacheck && cd /hacheck && python setup.py install --install-scripts=/usr/bin

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,0 +1,5 @@
+---
+type: debian
+overrides:
+  debian:
+    platforms: [trusty, xenial, bionic]

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ commands =
 
 [testenv:itest_trusty]
 setenv =
+    COMPOSE_PROJECT_NAME=nerve_tools_trusty
     COMPOSE_FILE = dockerfiles/itest/docker-compose-trusty.yml
 commands =
     docker-compose down
@@ -55,6 +56,7 @@ commands =
 
 [testenv:itest_xenial]
 setenv =
+    COMPOSE_PROJECT_NAME=nerve_tools_xenial
     COMPOSE_FILE = dockerfiles/itest/docker-compose-xenial.yml
 commands =
     docker-compose down
@@ -65,6 +67,7 @@ commands =
 
 [testenv:itest_bionic]
 setenv =
+    COMPOSE_PROJECT_NAME=nerve_tools_bionic
     COMPOSE_FILE = dockerfiles/itest/docker-compose-bionic.yml
 commands =
     docker-compose down


### PR DESCRIPTION
We build projects using Jenkins and Jenkinsfiles. This brings this project up-to-date with our current testing workflows.

Added 2 other fixes 
* Ensure required packages are up to date
* Ensure itests don't interfere with each other when run in parallel on the same host