### PR TITLE
Pin cryptography to v3.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 argparse==1.2.1
+cryptography==3.0
 dulwich==0.17.3
 environment_tools==1.1.3
 kazoo==2.2

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ docker_compose_version = 1.26.2
 indexserver = https://pypi.yelpcorp.com/simple
 deps =
     docker-compose=={[tox]docker_compose_version}
+    cryptography==3.0
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 setenv =
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}


### PR DESCRIPTION
### Description
This PR pins cryptography to v3.0 since later versions do not support OpenSSL 1.0.2, which is what we run and can't update from until we're off trusty and xenial. 

### Testing
`make itest_xenial` passes now