### PR TITLE
Downpin cryptography to 3.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 argparse==1.2.1
-cryptography==3.2
+# we're stuck on 3.0 until we get rid of the xenial stragglers
+cryptography==3.0
 dulwich==0.17.3
 environment_tools==1.1.3
 kazoo==2.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ indexserver = https://pypi.yelpcorp.com/simple
 basepython = python3.7
 deps =
     docker-compose==1.26.2
-    cryptography==3.2
+    # we're stuck on 3.0 until we get rid of the xenial stragglers
+    cryptography==3.0
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 setenv =
     TZ = UTC


### PR DESCRIPTION
We have a very small number of xenial boxes that install this package -
cryptography==3.2 doesn't like the version of OpenSSL installed on those
boxes so lets downpin until these stragglers are gone