### PR TITLE
Bump paasta-tools to 0.131.3 to get toggle to exclude terminated pods from configure_nerve

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ environment_tools==1.1.3
 kazoo==2.8.0
 ldap3==2.7
 mypy-extensions==0.4.3
-paasta-tools==0.105.0
+paasta-tools==0.131.3
 PyYAML==5.4
 requests==2.23.0
 service-configuration-lib==2.5.4


### PR DESCRIPTION
https://github.com/Yelp/paasta/pull/3355 was deployed in version 0.131.3 and adds an option to control whether we include terminating pods in nerve config or not (status quo is to include terminating pods).

This change itself should not change any behavior, we will also have to disable the `nerve_register_k8s_terminating` toggle on the paasta system side (currently defaults to true).