### PR TITLE
Call paasta_dump_locally_running_services and use the weight returned by that, …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,6 @@ release:
 	git show
 	@echo 'Now run `git push origin master $(RELEASE)` to release this version'
 
+.PHONY: test
 test:
 	$(MAKE) -C src test

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,5 @@ release:
 	git show
 	@echo 'Now run `git push origin master $(RELEASE)` to release this version'
 
+test:
+	$(MAKE) -C src test

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get -y install \
     git \
     libyaml-dev \
     libc6-dev \
-    libstdc++6
+    libstdc++6 \
+    wget
 
 RUN pip3 install pip==9.0.1
 RUN git clone https://github.com/Yelp/hacheck && cd /hacheck && pip3 install . && cp /usr/local/bin/* /usr/bin/

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-echo "Installing nerve-tools package"
-dpkg -i /work/dist/nerve-tools_*.deb
-
-# Set -e here because the previous install should fail lacking dependencies
-# and then we can fix it here
+set -vx
 set -e
+
+echo "installing paasta-tools (dependency of nerve-tools.)"
+. /etc/lsb-release
+PAASTA_VERSION=0.144.7
+PAASTA_DEB_NAME=paasta-tools_${PAASTA_VERSION}.${DISTRIB_CODENAME}1_amd64.deb
+wget "https://github.com/Yelp/paasta/releases/download/v${PAASTA_VERSION}/${PAASTA_DEB_NAME}"
+
+# We use || true here because any missing dependencies will cause dpkg -i to return an error.
+# We fix the missing dependencies later.
+dpkg -i "./${PAASTA_DEB_NAME}" || true
+
+echo "Installing nerve-tools package"
+dpkg -i /work/dist/nerve-tools_*.deb || true
+
+echo "Fixing missing dependencies"
 apt-get -y install -f
 
 echo "Testing that pyyaml uses optimized cyaml parsers if present"

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "installing paasta-tools (dependency of nerve-tools.)"
 . /etc/lsb-release
-PAASTA_VERSION=0.144.7
+PAASTA_VERSION=0.145.0
 PAASTA_DEB_NAME=paasta-tools_${PAASTA_VERSION}.${DISTRIB_CODENAME}1_amd64.deb
 wget "https://github.com/Yelp/paasta/releases/download/v${PAASTA_VERSION}/${PAASTA_DEB_NAME}"
 

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python3.7, paasta-tools (>= 0.145.0), ${shlibs:Depends}
+Depends: python3.7, paasta-tools (>= 0.145.0~), ${shlibs:Depends}
 Package: nerve-tools
 Architecture: any
 Description: Nerve-related tools for use on Yelp machines.

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python3.7, paasta-tools (>= 0.144.7), ${shlibs:Depends}
+Depends: python3.7, paasta-tools (>= 0.145.0), ${shlibs:Depends}
 Package: nerve-tools
 Architecture: any
 Description: Nerve-related tools for use on Yelp machines.

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python3.7, ${shlibs:Depends}
+Depends: python3.7, paasta-tools (>= 0.144.7), ${shlibs:Depends}
 Package: nerve-tools
 Architecture: any
 Description: Nerve-related tools for use on Yelp machines.

--- a/src/nerve_tools/config.py
+++ b/src/nerve_tools/config.py
@@ -40,6 +40,7 @@ class NerveConfig(TypedDict):
 
 
 class ServiceInfo(TypedDict, total=False):
+    # This corresponds to the entries in ServiceNamespaceConfig from paasta.
     port: int
     hacheck_ip: str
     service_ip: str
@@ -50,11 +51,12 @@ class ServiceInfo(TypedDict, total=False):
     healthcheck_mode: str
     advertise: Iterable[str]
     extra_advertise: Iterable[Tuple[str, str]]
-    extra_healthcheck_headers: Mapping[str, str]
+    extra_healthcheck_headers: Dict[str, str]
     healthcheck_body_expect: str
     paasta_instance: Optional[str]
     deploy_group: Optional[str]
     host: str
+    weight: int
 
 
 class ListenerAddress(TypedDict):

--- a/src/tests/configure_nerve_test.py
+++ b/src/tests/configure_nerve_test.py
@@ -90,7 +90,7 @@ def expected_sub_config():
                 'fall': 2,
                 'type': 'http',
                 'port': 6666,
-                'headers': {},
+                'headers': {'x-smartstack-expected-service': 'test_service'},
             }],
             'host': '10.0.0.1',
             'check_interval': 3.0,
@@ -117,7 +117,7 @@ def expected_sub_config():
                 'fall': 2,
                 'type': 'http',
                 'port': 6666,
-                'headers': {},
+                'headers': {'x-smartstack-expected-service': 'test_service'},
             }],
             'host': '10.0.0.1',
             'check_interval': 3.0,
@@ -396,14 +396,12 @@ def test_generate_configuration_paasta_service():
         }
 
         actual_config = configure_nerve.generate_configuration(
-            paasta_services=[(
+            services=[(
                 'test_service',
                 mock_service_info,
             )],
-            puppet_services=[],
             heartbeat_path='test',
             hacheck_port=6666,
-            weight=mock.sentinel.classic_weight,
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
@@ -479,7 +477,7 @@ def test_generate_configuration_paasta_service_with_envoy_ingress_listeners():
         })
 
         actual_config = generate_configuration(
-            paasta_services=[
+            services=[
                 (
                     'test_service.main',
                     mock_service_info,
@@ -489,10 +487,8 @@ def test_generate_configuration_paasta_service_with_envoy_ingress_listeners():
                     mock_service_info,
                 )
             ],
-            puppet_services=[],
             heartbeat_path='test',
             hacheck_port=6666,
-            weight=mock.sentinel.classic_weight,
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
@@ -561,14 +557,12 @@ def test_generate_configuration_healthcheck_port():
         }
 
         actual_config = configure_nerve.generate_configuration(
-            paasta_services=[(
+            services=[(
                 'test_service',
                 mock_service_info,
             )],
-            puppet_services=[],
             heartbeat_path='test',
             hacheck_port=6666,
-            weight=mock.sentinel.classic_weight,
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
@@ -624,14 +618,12 @@ def test_generate_configuration_healthcheck_mode():
         }
 
         actual_config = configure_nerve.generate_configuration(
-            paasta_services=[(
+            services=[(
                 'test_service',
                 mock_service_info,
             )],
-            puppet_services=[],
             heartbeat_path='test',
             hacheck_port=6666,
-            weight=mock.sentinel.classic_weight,
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
@@ -665,11 +657,9 @@ def test_generate_configuration_empty():
     ):
 
         configuration = configure_nerve.generate_configuration(
-            paasta_services=[],
-            puppet_services=[],
+            services=[],
             heartbeat_path="",
             hacheck_port=6666,
-            weight=mock.sentinel.classic_weight,
             zk_topology_dir='/fake/path',
             zk_location_type='fake_zk_location_type',
             zk_cluster_type='fake_cluster_type',
@@ -692,9 +682,7 @@ def setup_mocks_for_main():
     with patch.object(
         sys, 'argv', ['configure-nerve']
     ) as mock_sys, patch(
-        'nerve_tools.configure_nerve.get_marathon_services_running_here_for_nerve'
-    ), patch(
-        'nerve_tools.configure_nerve.get_paasta_native_services_running_here_for_nerve'
+        'nerve_tools.configure_nerve.call_paasta_dump_locally_running_services'
     ), patch(
         'nerve_tools.configure_nerve.generate_configuration'
     ), patch(

--- a/src/tests/updown_service_test.py
+++ b/src/tests/updown_service_test.py
@@ -253,6 +253,7 @@ def test_check_envoy_state_missing_eds_file(tmp_path):
             str(tmp_path),
         ) is False
 
+
 @pytest.mark.parametrize(
     "check_envoy_state_side_effect,expected_result,expected_iterations", [
         # Service is immediately in the expected state


### PR DESCRIPTION
… instead of calculating weight here. This allows paasta to control weight.

Corresponding paasta PR: https://github.com/Yelp/paasta/pull/3450

As a side effect, this fixes the pytest tests, and gets us very close to removing paasta_tools as a python dependency. (Just need to check whether updown_service is used or not.)