### PR TITLE
COMPINFRA-1515, add meta-data that nerve-tools breaks if paasta-tools version is less than v0.145.0

### DIFF
--- a/src/debian/control
+++ b/src/debian/control
@@ -4,6 +4,7 @@ Build-Depends:
     dh-virtualenv,
 
 Depends: python3.7, paasta-tools (>= 0.145.0~), ${shlibs:Depends}
+Breaks: paasta-tools (< 0.145.0~)
 Package: nerve-tools
 Architecture: any
 Description: Nerve-related tools for use on Yelp machines.


### PR DESCRIPTION
In recent pager storm we saw that puppet was installing the wrong version of paasta-tools in yr-prod that was pinned in hieradata. The reason for the pages was that nerve-tools latest version `v2.2.1` needed paasta-tools version >= `v0.145.0`, but the pinned version was `0.139.3` This caused an issue in the version of the paaasta-tools package installed and the version returned from the API Therefore adding meta-data for it so it breaks any puppet build if it happens.