### PR TITLE
Delete Jenkins config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,0 @@
-overrides = [
-  clone: [
-    gitServer: 'git@github.com',
-    repoBranch: 'origin/master',
-  ],
-  platforms: ['bionic', 'jammy']
-]
-buildDebianPackage(overrides)

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,5 +1,0 @@
----
-type: debian
-overrides:
-  debian:
-    platforms: [bionic, jammy]


### PR DESCRIPTION
There's internal automation that will disable Jenkins jobs that don't show up in an internal repos jenkins.yaml which is leading to the pipeline for this job getting disabled.

I've already brought this config in-house, and this is just some cleanup to not confuse us in the future