### PR TITLE
Fix build libcrypto errors

### DIFF
--- a/src/debian/rules
+++ b/src/debian/rules
@@ -26,3 +26,7 @@ override_dh_virtualenv:
 	dh_virtualenv -i $(PIP_INDEX_URL) \
 	--python=/usr/bin/python3.7 \
 	--preinstall no-manylinux1
+
+# For some reason dh virtualenv can't find libcrypto bundled but this seems to work. Probably there is a real fix somewhere?
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=-ldebian/nerve-tools/opt/venvs/nerve-tools/lib/python3.7/site-packages/cryptography.libs

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
 
 [testenv:package_bionic]
-whitelist_externals = /bin/cp
+allowlist_externals = cp
 setenv =
     COMPOSE_FILE = dockerfiles/bionic/docker-compose.yml
 commands =
@@ -27,7 +27,7 @@ commands =
     docker-compose rm --force
 
 [testenv:package_jammy]
-whitelist_externals = /bin/cp
+allowlist_externals = cp
 setenv =
     COMPOSE_FILE = dockerfiles/jammy/docker-compose.yml
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skipsdist = true
 indexserver = https://pypi.yelpcorp.com/simple
 basepython = python3.7
 deps =
-    docker-compose==1.26.2
+    docker-compose==1.29.2
     cryptography==35.0.0
-passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
+passenv = DOCKER_TLS_VERIFY,DOCKER_HOST,DOCKER_CERT_PATH
 setenv =
     TZ = UTC
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}


### PR DESCRIPTION
For some reason dh_virtualenv couldn't find bundled libcrypto. This fixes that error. hacheck is also private now so the build may still be broken? But one thing at a time...